### PR TITLE
CI: Copy prisma files in final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN chown node:node .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/prisma ./prisma
 
 USER node
 


### PR DESCRIPTION
## Summary

Copy prisma files in final docker image, so that we can run the prisma deploy as a post-deployment script in Coolify