### PR TITLE
feat: support group activities with up to 10 participants

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,7 +35,10 @@ Driving to and from clients (home → client → home). Billed as NDIS "Provider
 The distance and travel time between two clients in a Trip. Entered manually by the provider for each leg. Used to calculate Provider Travel for middle and last activities in a Trip.
 
 **Transit Rate**
-The per-kilometre rate charged for Provider Travel. Defaults to the User's configured rate (max $0.99/km per NDIS rules). Can be overridden per Client. Separate rates exist for individual activities (`transitRatePerKm`) and group activities (`groupTransitRatePerKm`).
+The per-kilometre rate charged for Provider Travel. Defaults to the User's configured rate (max $0.99/km per NDIS rules). Can be overridden per Client. For group activities, the resolved rate is apportioned by participant count — see **Group Activity**.
+
+**Group Activity**
+An Activity delivered to 2–10 Melvin Clients at once, recorded as one mirrored Activity per participant sharing a `groupSize` (the participant count at creation; membership is immutable afterwards). A group Support Item's stored rate holds the full per-session amount; each participant is billed `floorToCent(rate ÷ groupSize)` for the hourly support rate, Provider Travel per-km, and Activity Based Transport per-km alike.
 
 **Travel Time Cap**
 NDIS MMM1-3 regions limit claimable travel time to 30 minutes per leg. Applied as a hard cap during transit calculation, with a warning shown when exceeded.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,19 +6,17 @@ See `manage-plans` skill for lifecycle conventions. TRDs in [`docs/trd/`](../trd
 
 | Plan | Title                                                          | Priority | Effort | Depends on | Status |
 | ---- | -------------------------------------------------------------- | -------- | ------ | ---------- | ------ |
-| 016  | Group activities with up to 10 participants                    | P2       | L      | 006, 007   | TODO   |
 | 017  | Invoice versioning — sent invoices freeze an immutable version | P1       | L      | 007        | TODO   |
 
 Status: `TODO` | `IN PROGRESS` | `DONE` | `BLOCKED (reason)` | `REJECTED (rationale)`
 
 ## Completed
 
-In [`complete/`](complete/): 001, 002, 003, 004, 005, 006, 007, 008, 009, 010, 011, 012, 015. Rejected: 013 (superseded by 005–008).
+In [`complete/`](complete/): 001, 002, 003, 004, 005, 006, 007, 008, 009, 010, 011, 012, 015, 016. Rejected: 013 (superseded by 005–008).
 
 ## Dependency Notes
 
 - **002, 003** — independent, can run in parallel
 - **006 → 005** — needs characterization safety net (001, 004, 005 done). Revised 2026-07-07: `f8e5097` already single-sourced the rate (incl. the group 0.43); remaining work is threading `rateContext` + client rates
 - **009 → 003** — regression net for ownership rules
-- **016 → 006, 007** — apportions all group rates by participant count inside 007's `billableLines` seam; 006's effective transit rate is the base it divides
-- **017 → 007** — `send` freezes the `BillableLine[]` that 007's seam computes, and version PDFs render through 007's pure `renderInvoicePdf`. Independent of 016, but if 016 lands first the snapshot schema must match the live `BillableLine` shape (see plan 017 STOP conditions). Design authority: ADR 0004 (supersedes TRD-006 D1/D2 mechanism and ADR 0003 for locked invoices)
+- **017 → 007** — `send` freezes the `BillableLine[]` that 007's seam computes, and version PDFs render through 007's pure `renderInvoicePdf`. Design authority: ADR 0004 (supersedes TRD-006 D1/D2 mechanism and ADR 0003 for locked invoices). 016 has landed — the snapshot schema must account for `BillableLine`'s current shape (post-016 group apportioning).

--- a/docs/plans/complete/016-group-activities-up-to-10-participants.md
+++ b/docs/plans/complete/016-group-activities-up-to-10-participants.md
@@ -17,6 +17,7 @@
 
 ## Status
 
+- **State**: DONE (2026-07-07)
 - **Priority**: P2
 - **Effort**: L
 - **Risk**: MED–HIGH (schema + data migration; redefines what a group support item's stored rate MEANS; billing-visible cent changes documented below)
@@ -288,15 +289,15 @@ documented lines plus the one new fixture's files.
 
 Machine-checkable. ALL must hold:
 
-- [ ] `grep -rn "GROUP_TRANSIT_RATE\|Handle groups other than 2" src/lib` → no matches
-- [ ] `grep -rn "0.49" src/lib --include="*.ts" | grep -v test | grep -v testing` → no matches (ABT group rate is computed, not hardcoded)
-- [ ] `grep -n "groupSize" prisma/schema.prisma` → one match on `Activity`; migration file includes both backfill UPDATEs
-- [ ] `grep -n "groupClientIds" src/schema/invoice-schema.ts` → array with `.max(9)`
-- [ ] New N=3 fixture + goldens exist; `pnpm exec vitest run` exits 0
-- [ ] Golden diffs for pre-existing fixtures touch only `transit-group` and `plan-managed-week` (the $0.43→$0.42 lines and totals)
-- [ ] `pnpm type-check`, `pnpm lint`, `pnpm format:check` exit 0
-- [ ] CONTEXT.md no longer mentions `groupTransitRatePerKm`
-- [ ] `docs/plans/README.md` status row updated
+- [x] `grep -rn "GROUP_TRANSIT_RATE\|Handle groups other than 2" src/lib` → no matches
+- [x] `grep -rn "0.49" src/lib --include="*.ts" | grep -v test | grep -v testing` → no matches (ABT group rate is computed, not hardcoded)
+- [x] `grep -n "groupSize" prisma/schema.prisma` → one match on `Activity`; migration file includes both backfill UPDATEs
+- [x] `grep -n "groupClientIds" src/schema/invoice-schema.ts` → array with `.max(9)`
+- [x] New N=3 fixture + goldens exist; `pnpm exec vitest run` exits 0
+- [x] Golden diffs for pre-existing fixtures touch only `transit-group` and `plan-managed-week` (the $0.43→$0.42 lines and totals)
+- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check` exit 0
+- [x] CONTEXT.md no longer mentions `groupTransitRatePerKm`
+- [x] `docs/plans/README.md` status row updated
 
 ## STOP conditions
 

--- a/e2e/invoice-pdf.test.ts
+++ b/e2e/invoice-pdf.test.ts
@@ -1,3 +1,4 @@
+import { floorToCent } from "@/lib/generic-utils";
 import { extractPdfText } from "@/lib/testing/pdf-test-utils";
 import prisma from "@/server/prisma";
 import { expect, test } from "@playwright/test";
@@ -67,7 +68,10 @@ test("Realistic plan-managed invoice: group and solo travel codes in the PDF", a
 	expect(text).toContain("04_591_0136_6_1"); // group activity transport
 	expect(text).toContain("$0.49/km");
 	expect(text).toContain("04_799_0136_6_1"); // group non-labour travel
-	expect(text).toContain("$0.43/km");
+	// docs/plans/016: group provider travel apportions the effective rate by
+	// group size (defaults to 2) — testUser's transitRatePerKm is 0.99 (schema
+	// default), which coincides with the ABT group rate above.
+	expect(text).toContain(`$${floorToCent(0.99 / 2).toFixed(2)}/km`);
 	expect(text).toContain("04_799_0125_6_1"); // solo non-labour travel
 	expect(text).toContain("$0.99/km"); // testUser's transitRatePerKm (schema default)
 
@@ -75,7 +79,8 @@ test("Realistic plan-managed invoice: group and solo travel codes in the PDF", a
 	expect(text).toContain("13:20-14:25 (1 hour, 5 mins)");
 
 	// The printed Total equals getTotalCostOfActivities over the same
-	// activities — group travel priced at $0.43/km on both sides (Q1 fixed)
+	// activities — group travel priced at the apportioned rate on both sides
+	// (Q1 fixed; docs/plans/016)
 	expect(text).toContain(`$${expectedPdfTotal.toFixed(2)}`);
 });
 

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -258,7 +258,10 @@ export async function createRealisticInvoice() {
 			rateType: "HOUR",
 			isGroup: true,
 			weekdayCode: "04_102_0136_6_1",
-			weekdayRate: 35.1,
+			// Full-session rate (docs/plans/016): billing apportions this by the
+			// activity's groupSize (defaults to 2), reproducing the original
+			// per-participant rate of 35.10.
+			weekdayRate: 70.2,
 			ownerId: testUser.id
 		}
 	});

--- a/prisma/migrations/20260707113523_add_activity_group_size/migration.sql
+++ b/prisma/migrations/20260707113523_add_activity_group_size/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE "Activity" ADD COLUMN     "groupSize" INTEGER;
+
+-- Backfill: existing group activities were all created with exactly 2
+-- participants (docs/plans/016) — every isGroup activity gets groupSize = 2.
+UPDATE "Activity" SET "groupSize" = 2 WHERE "supportItemId" IN (SELECT id FROM "SupportItem" WHERE "isGroup" = true);
+
+-- Rate-semantics migration (docs/plans/016, operator decision 3): a group
+-- support item's stored rates move from "per-participant" to "full-session"
+-- meaning, so billing (which now divides by groupSize) reproduces the same
+-- per-participant cents for existing N=2 groups.
+UPDATE "SupportItem"
+SET "weekdayRate" = "weekdayRate" * 2,
+    "weeknightRate" = "weeknightRate" * 2,
+    "saturdayRate" = "saturdayRate" * 2,
+    "sundayRate" = "sundayRate" * 2
+WHERE "isGroup" = true;
+
+UPDATE "SupportItemRates"
+SET "weekdayRate" = "weekdayRate" * 2,
+    "weeknightRate" = "weeknightRate" * 2,
+    "saturdayRate" = "saturdayRate" * 2,
+    "sundayRate" = "sundayRate" * 2
+WHERE "supportItemId" IN (SELECT id FROM "SupportItem" WHERE "isGroup" = true);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,7 @@ model Activity {
   transitDuration Decimal?
   transitDistance Decimal?
   itemDistance    Int?
+  groupSize       Int?
   ownerId         String?
   clientId        String?
   supportItemId   String

--- a/src/components/activities/multi-activity-form.tsx
+++ b/src/components/activities/multi-activity-form.tsx
@@ -24,6 +24,7 @@ import type {
 	ActivitySchema,
 	ActivityTransportItemSchema
 } from "@/schema/activity-schema";
+import { MAX_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
 import dayjs from "dayjs";
 import {
 	ChevronDown,
@@ -41,7 +42,7 @@ interface ActivityRowData {
 	id: string;
 	clientId: string;
 	isGroup: boolean;
-	groupClientId: string;
+	groupClientIds: string[];
 	timeRange: TimeRangeValue;
 	transportKm: number | undefined;
 	transportItems: ActivityTransportItemSchema[];
@@ -59,7 +60,7 @@ function createEmptyRow(): ActivityRowData {
 		id: crypto.randomUUID(),
 		clientId: "",
 		isGroup: false,
-		groupClientId: "",
+		groupClientIds: [],
 		timeRange: { startTime: "", endTime: "" },
 		transportKm: undefined,
 		transportItems: [],
@@ -154,8 +155,8 @@ export function MultiActivityForm({
 				isValid = false;
 			}
 
-			if (row.isGroup && !row.groupClientId) {
-				errors.groupClient = "Second participant is required";
+			if (row.isGroup && row.groupClientIds.length === 0) {
+				errors.groupClient = "At least one other participant is required";
 				isValid = false;
 			}
 
@@ -215,6 +216,11 @@ export function MultiActivityForm({
 				? row.supportItemId || defaultGroupSupportItemId || ""
 				: row.supportItemId || defaultSupportItemId || "";
 
+			const groupSize =
+				row.isGroup && row.groupClientIds.length > 0
+					? row.groupClientIds.length + 1
+					: undefined;
+
 			// Primary client activity (always created)
 			activities.push({
 				clientId: row.clientId,
@@ -222,20 +228,24 @@ export function MultiActivityForm({
 				startTime: row.timeRange.startTime,
 				endTime: row.timeRange.endTime,
 				supportItemId,
+				groupSize,
 				transportItems: transportItems.length > 0 ? transportItems : undefined
 			});
 
-			// Second participant activity (only for group activities)
-			if (row.isGroup && row.groupClientId) {
+			// Other participants' activities (only for group activities)
+			if (row.isGroup && row.groupClientIds.length > 0) {
 				hasGroupActivities = true;
-				activities.push({
-					clientId: row.groupClientId,
-					date: stripTimezone(date),
-					startTime: row.timeRange.startTime,
-					endTime: row.timeRange.endTime,
-					supportItemId
-					// No transport items for second participant
-				});
+				for (const groupClientId of row.groupClientIds) {
+					activities.push({
+						clientId: groupClientId,
+						date: stripTimezone(date),
+						startTime: row.timeRange.startTime,
+						endTime: row.timeRange.endTime,
+						supportItemId,
+						groupSize
+						// No transport items for other participants
+					});
+				}
 			}
 		});
 
@@ -372,8 +382,28 @@ function ActivityRow({
 	const handleGroupToggle = () => {
 		onUpdate({
 			isGroup: !row.isGroup,
-			groupClientId: !row.isGroup ? "" : row.groupClientId,
+			groupClientIds: !row.isGroup ? [] : row.groupClientIds,
 			errors: { ...row.errors, groupClient: undefined }
+		});
+	};
+
+	const updateGroupClientId = (index: number, clientId: string) => {
+		const groupClientIds = [...row.groupClientIds];
+		groupClientIds[index] = clientId;
+		onUpdate({
+			groupClientIds,
+			errors: { ...row.errors, groupClient: undefined }
+		});
+	};
+
+	const addGroupParticipant = () => {
+		if (row.groupClientIds.length >= MAX_GROUP_PARTICIPANTS) return;
+		onUpdate({ groupClientIds: [...row.groupClientIds, ""] });
+	};
+
+	const removeGroupParticipant = (index: number) => {
+		onUpdate({
+			groupClientIds: row.groupClientIds.filter((_, i) => i !== index)
 		});
 	};
 
@@ -441,18 +471,44 @@ function ActivityRow({
 				{row.isGroup && (
 					<div>
 						<Label className={cn(row.errors.groupClient && "text-destructive")}>
-							Second participant
+							Other participants
 						</Label>
-						<ClientQuickSelect
-							value={row.groupClientId}
-							onChange={(groupClientId) =>
-								onUpdate({
-									groupClientId,
-									errors: { ...row.errors, groupClient: undefined }
-								})
-							}
-							excludeClientId={row.clientId}
-						/>
+						<div className="flex flex-col gap-2">
+							{row.groupClientIds.map((groupClientId, participantIndex) => (
+								<div key={participantIndex} className="flex items-center gap-2">
+									<div className="flex-1">
+										<ClientQuickSelect
+											value={groupClientId}
+											onChange={(clientId) =>
+												updateGroupClientId(participantIndex, clientId)
+											}
+											excludeClientId={row.clientId}
+											excludeClientIds={row.groupClientIds.filter(
+												(_, i) => i !== participantIndex
+											)}
+										/>
+									</div>
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onClick={() => removeGroupParticipant(participantIndex)}
+										className="text-destructive hover:text-destructive h-8 w-8 p-0"
+									>
+										<Trash2 className="h-4 w-4" />
+									</Button>
+								</div>
+							))}
+						</div>
+						{row.groupClientIds.length < MAX_GROUP_PARTICIPANTS && (
+							<button
+								type="button"
+								onClick={addGroupParticipant}
+								className="text-muted-foreground hover:text-foreground mt-2 text-left text-sm underline-offset-4 hover:underline"
+							>
+								+ add participant
+							</button>
+						)}
 						{row.errors.groupClient && (
 							<p className="text-destructive mt-1 text-sm">
 								{row.errors.groupClient}

--- a/src/components/activities/multi-activity-form.tsx
+++ b/src/components/activities/multi-activity-form.tsx
@@ -24,7 +24,15 @@ import type {
 	ActivitySchema,
 	ActivityTransportItemSchema
 } from "@/schema/activity-schema";
-import { MAX_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
+import {
+	appendParticipant,
+	removeParticipantAt,
+	setParticipantAt
+} from "@/lib/group-participants";
+import {
+	MAX_ADDITIONAL_GROUP_PARTICIPANTS,
+	totalGroupSize
+} from "@/schema/invoice-schema";
 import dayjs from "dayjs";
 import {
 	ChevronDown,
@@ -218,7 +226,7 @@ export function MultiActivityForm({
 
 			const groupSize =
 				row.isGroup && row.groupClientIds.length > 0
-					? row.groupClientIds.length + 1
+					? totalGroupSize(row.groupClientIds)
 					: undefined;
 
 			// Primary client activity (always created)
@@ -387,25 +395,20 @@ function ActivityRow({
 		});
 	};
 
-	const updateGroupClientId = (index: number, clientId: string) => {
-		const groupClientIds = [...row.groupClientIds];
-		groupClientIds[index] = clientId;
+	const setGroupClientIds = (groupClientIds: string[]) =>
 		onUpdate({
 			groupClientIds,
 			errors: { ...row.errors, groupClient: undefined }
 		});
-	};
 
-	const addGroupParticipant = () => {
-		if (row.groupClientIds.length >= MAX_GROUP_PARTICIPANTS) return;
-		onUpdate({ groupClientIds: [...row.groupClientIds, ""] });
-	};
+	const updateGroupClientId = (index: number, clientId: string) =>
+		setGroupClientIds(setParticipantAt(row.groupClientIds, index, clientId));
 
-	const removeGroupParticipant = (index: number) => {
-		onUpdate({
-			groupClientIds: row.groupClientIds.filter((_, i) => i !== index)
-		});
-	};
+	const addGroupParticipant = () =>
+		setGroupClientIds(appendParticipant(row.groupClientIds));
+
+	const removeGroupParticipant = (index: number) =>
+		setGroupClientIds(removeParticipantAt(row.groupClientIds, index));
 
 	return (
 		<div className="bg-muted/30 relative rounded-lg border p-4">
@@ -500,7 +503,7 @@ function ActivityRow({
 								</div>
 							))}
 						</div>
-						{row.groupClientIds.length < MAX_GROUP_PARTICIPANTS && (
+						{row.groupClientIds.length < MAX_ADDITIONAL_GROUP_PARTICIPANTS && (
 							<button
 								type="button"
 								onClick={addGroupParticipant}

--- a/src/components/forms/client-quick-select.tsx
+++ b/src/components/forms/client-quick-select.tsx
@@ -18,6 +18,7 @@ interface ClientQuickSelectProps {
 	onChange?: (clientId: string) => void;
 	className?: string;
 	excludeClientId?: string;
+	excludeClientIds?: string[];
 }
 
 function getRecentClientIds(): string[] {
@@ -48,7 +49,8 @@ export function ClientQuickSelect({
 	value,
 	onChange,
 	className,
-	excludeClientId
+	excludeClientId,
+	excludeClientIds
 }: ClientQuickSelectProps) {
 	const [open, setOpen] = React.useState(false);
 	const [search, setSearch] = React.useState("");
@@ -63,8 +65,9 @@ export function ClientQuickSelect({
 	const selectedClient = clients?.find((c) => c.id === value);
 
 	const availableClients = React.useMemo(() => {
-		return clients?.filter((c) => c.id !== excludeClientId) ?? [];
-	}, [clients, excludeClientId]);
+		const excluded = new Set([excludeClientId, ...(excludeClientIds ?? [])]);
+		return clients?.filter((c) => !excluded.has(c.id)) ?? [];
+	}, [clients, excludeClientId, excludeClientIds]);
 
 	const filteredClients = React.useMemo(() => {
 		if (!search.trim()) return availableClients;

--- a/src/components/forms/client-select.tsx
+++ b/src/components/forms/client-select.tsx
@@ -7,21 +7,28 @@ interface ClientSelectProps extends Omit<
 	"placeholder" | "options"
 > {
 	excludeClientId?: string;
+	excludeClientIds?: string[];
 }
 
-function ClientSelect({ excludeClientId, ...props }: ClientSelectProps) {
+function ClientSelect({
+	excludeClientId,
+	excludeClientIds,
+	...props
+}: ClientSelectProps) {
 	const { data: { clients } = {} } = trpc.clients.list.useQuery({});
 
-	const options = useMemo(
-		() =>
+	const options = useMemo(() => {
+		const excluded = new Set([excludeClientId, ...(excludeClientIds ?? [])]);
+
+		return (
 			clients
-				?.filter((client) => client.id !== excludeClientId)
+				?.filter((client) => !excluded.has(client.id))
 				.map((client) => ({
 					label: client.name,
 					value: client.id
-				})) ?? [],
-		[clients, excludeClientId]
-	);
+				})) ?? []
+		);
+	}, [clients, excludeClientId, excludeClientIds]);
 
 	return (
 		<FormSelect options={options} placeholder="Select a client..." {...props} />

--- a/src/components/invoices/invoice-activity-creation-form.tsx
+++ b/src/components/invoices/invoice-activity-creation-form.tsx
@@ -18,7 +18,7 @@ import {
 import { stripTimezone } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import { InvoiceSchema } from "@/schema/invoice-schema";
+import { InvoiceSchema, MAX_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
 import { format } from "date-fns";
 import {
 	ArrowRight,
@@ -137,10 +137,47 @@ const InvoiceActivityCreationForm = ({
 	useEffect(() => {
 		activitiesToCreate?.forEach((activity, idx) => {
 			if (isGroupSupportItem(activity.supportItemId)) {
-				setValue(`activitiesToCreate.${idx}.groupClientId`, "");
+				setValue(`activitiesToCreate.${idx}.groupClientIds`, []);
 			}
 		});
 	}, [isGroupSupportItem, setValue, activitiesToCreate]);
+
+	const updateGroupClientId = (
+		activityIndex: number,
+		participantIndex: number,
+		clientId: string
+	) => {
+		const groupClientIds = [
+			...(getValues().activitiesToCreate[activityIndex].groupClientIds ?? [])
+		];
+		groupClientIds[participantIndex] = clientId;
+		setValue(
+			`activitiesToCreate.${activityIndex}.groupClientIds`,
+			groupClientIds
+		);
+	};
+
+	const addGroupParticipant = (activityIndex: number) => {
+		const groupClientIds =
+			getValues().activitiesToCreate[activityIndex].groupClientIds ?? [];
+		if (groupClientIds.length >= MAX_GROUP_PARTICIPANTS) return;
+		setValue(`activitiesToCreate.${activityIndex}.groupClientIds`, [
+			...groupClientIds,
+			""
+		]);
+	};
+
+	const removeGroupParticipant = (
+		activityIndex: number,
+		participantIndex: number
+	) => {
+		const groupClientIds =
+			getValues().activitiesToCreate[activityIndex].groupClientIds ?? [];
+		setValue(
+			`activitiesToCreate.${activityIndex}.groupClientIds`,
+			groupClientIds.filter((_, i) => i !== participantIndex)
+		);
+	};
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -164,24 +201,6 @@ const InvoiceActivityCreationForm = ({
 										</FormItem>
 									)}
 								/>
-								{isGroupSupportItem(
-									watch("activitiesToCreate")[index].supportItemId
-								) && (
-									<FormField
-										name={`activitiesToCreate.${index}.groupClientId`}
-										control={control}
-										render={({ field }) => (
-											<FormItem className="shrink grow basis-1/2">
-												<ClientSelect
-													excludeClientId={watch("clientId")}
-													onValueChange={field.onChange}
-													value={field.value}
-												/>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-								)}
 								<Button
 									variant="ghost"
 									size="icon"
@@ -191,6 +210,68 @@ const InvoiceActivityCreationForm = ({
 									<X className="h-6 w-6" />
 								</Button>
 							</div>
+
+							{isGroupSupportItem(
+								watch("activitiesToCreate")[index].supportItemId
+							) && (
+								<div className="mb-2 flex flex-col gap-2">
+									{(
+										watch(`activitiesToCreate.${index}.groupClientIds`) ?? []
+									).map((groupClientId, participantIndex) => (
+										<div
+											key={participantIndex}
+											className="flex items-center gap-2"
+										>
+											<div className="shrink grow basis-1/2">
+												<ClientSelect
+													excludeClientId={watch("clientId")}
+													excludeClientIds={(
+														watch(
+															`activitiesToCreate.${index}.groupClientIds`
+														) ?? []
+													).filter((_, i) => i !== participantIndex)}
+													onValueChange={(clientId) =>
+														updateGroupClientId(
+															index,
+															participantIndex,
+															clientId
+														)
+													}
+													value={groupClientId}
+												/>
+											</div>
+											<Button
+												variant="ghost"
+												size="icon"
+												onClick={() =>
+													removeGroupParticipant(index, participantIndex)
+												}
+												type="button"
+											>
+												<X className="h-6 w-6" />
+											</Button>
+										</div>
+									))}
+									{(watch(`activitiesToCreate.${index}.groupClientIds`) ?? [])
+										.length < MAX_GROUP_PARTICIPANTS && (
+										<Button
+											onClick={() => addGroupParticipant(index)}
+											className="mr-auto"
+											variant="outline"
+											size="sm"
+											type="button"
+										>
+											+ Add Participant
+										</Button>
+									)}
+									{(watch(`activitiesToCreate.${index}.groupClientIds`) ?? [])
+										.length === 0 && (
+										<p className="text-destructive text-sm">
+											At least one other participant is required
+										</p>
+									)}
+								</div>
+							)}
 
 							<ul className="tree">
 								{fields[index].activities.map((_, activityFieldIndex) => (
@@ -333,7 +414,7 @@ const InvoiceActivityCreationForm = ({
 				onClick={() =>
 					appendActivityGroup({
 						supportItemId: "",
-						groupClientId: "",
+						groupClientIds: [],
 						activities: [{ date: stripTimezone(new Date()) }]
 					})
 				}

--- a/src/components/invoices/invoice-activity-creation-form.tsx
+++ b/src/components/invoices/invoice-activity-creation-form.tsx
@@ -18,7 +18,15 @@ import {
 import { stripTimezone } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import { InvoiceSchema, MAX_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
+import {
+	appendParticipant,
+	removeParticipantAt,
+	setParticipantAt
+} from "@/lib/group-participants";
+import {
+	InvoiceSchema,
+	MAX_ADDITIONAL_GROUP_PARTICIPANTS
+} from "@/schema/invoice-schema";
 import { format } from "date-fns";
 import {
 	ArrowRight,
@@ -142,42 +150,46 @@ const InvoiceActivityCreationForm = ({
 		});
 	}, [isGroupSupportItem, setValue, activitiesToCreate]);
 
-	const updateGroupClientId = (
-		activityIndex: number,
-		participantIndex: number,
-		clientId: string
-	) => {
-		const groupClientIds = [
-			...(getValues().activitiesToCreate[activityIndex].groupClientIds ?? [])
-		];
-		groupClientIds[participantIndex] = clientId;
+	const setGroupClientIds = (activityIndex: number, groupClientIds: string[]) =>
 		setValue(
 			`activitiesToCreate.${activityIndex}.groupClientIds`,
 			groupClientIds
 		);
-	};
 
-	const addGroupParticipant = (activityIndex: number) => {
-		const groupClientIds =
-			getValues().activitiesToCreate[activityIndex].groupClientIds ?? [];
-		if (groupClientIds.length >= MAX_GROUP_PARTICIPANTS) return;
-		setValue(`activitiesToCreate.${activityIndex}.groupClientIds`, [
-			...groupClientIds,
-			""
-		]);
-	};
+	const currentGroupClientIds = (activityIndex: number): string[] =>
+		getValues().activitiesToCreate[activityIndex].groupClientIds ?? [];
+
+	const updateGroupClientId = (
+		activityIndex: number,
+		participantIndex: number,
+		clientId: string
+	) =>
+		setGroupClientIds(
+			activityIndex,
+			setParticipantAt(
+				currentGroupClientIds(activityIndex),
+				participantIndex,
+				clientId
+			)
+		);
+
+	const addGroupParticipant = (activityIndex: number) =>
+		setGroupClientIds(
+			activityIndex,
+			appendParticipant(currentGroupClientIds(activityIndex))
+		);
 
 	const removeGroupParticipant = (
 		activityIndex: number,
 		participantIndex: number
-	) => {
-		const groupClientIds =
-			getValues().activitiesToCreate[activityIndex].groupClientIds ?? [];
-		setValue(
-			`activitiesToCreate.${activityIndex}.groupClientIds`,
-			groupClientIds.filter((_, i) => i !== participantIndex)
+	) =>
+		setGroupClientIds(
+			activityIndex,
+			removeParticipantAt(
+				currentGroupClientIds(activityIndex),
+				participantIndex
+			)
 		);
-	};
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -253,7 +265,7 @@ const InvoiceActivityCreationForm = ({
 										</div>
 									))}
 									{(watch(`activitiesToCreate.${index}.groupClientIds`) ?? [])
-										.length < MAX_GROUP_PARTICIPANTS && (
+										.length < MAX_ADDITIONAL_GROUP_PARTICIPANTS && (
 										<Button
 											onClick={() => addGroupParticipant(index)}
 											className="mr-auto"

--- a/src/lib/__pdf_text__/plan-managed-week.txt
+++ b/src/lib/__pdf_text__/plan-managed-week.txt
@@ -29,10 +29,10 @@ costs
 Provider travel - non-labour | 22/06/23 | 26 km | $0.85/km | $22.10
 costs | 24/06/23 | 26 km | $0.85/km | $22.10
 04_799_0125_6_1
-Provider travel - non-labour | 20/06/23 | 13 km | $0.43/km | $5.59
+Provider travel - non-labour | 20/06/23 | 13 km | $0.42/km | $5.46
 costs
 04_799_0136_6_1
-Total | $1153.59
+Total | $1153.46
 Marlee Provider
 ABN: 12 345 678 901
 Bank: Sample Bank

--- a/src/lib/__pdf_text__/transit-group.txt
+++ b/src/lib/__pdf_text__/transit-group.txt
@@ -8,10 +8,10 @@ Group Activities - Standard | 11/01/23 | 09:00-11:00 (2 hours) | $62.17/hr | $12
 Provider travel - labour | 11/01/23 | 30 minutes | $62.17/hr | $31.09
 costs
 04_102_0136_6_1
-Provider travel - non-labour | 11/01/23 | 15 km | $0.43/km | $6.45
+Provider travel - non-labour | 11/01/23 | 15 km | $0.42/km | $6.30
 costs
 04_799_0136_6_1
-Total | $161.88
+Total | $161.73
 Marlee Provider
 ABN: 12 345 678 901
 Bank: Sample Bank

--- a/src/lib/__pdf_text__/transport-group-three-participants.txt
+++ b/src/lib/__pdf_text__/transport-group-three-participants.txt
@@ -1,0 +1,21 @@
+=== Page 1 ===
+Invoice Number: GROUP3-1 | Tax Invoice
+Invoice Date: 01/02/23
+Participant Name: Jane Citizen
+Description | Date | Details | Unit Price | Total
+Activity Based Transport | 11/01/23 | 22 km | $0.33/km | $7.26
+04_591_0136_6_1
+Group Activities - Standard | 11/01/23 | 09:00-11:00 (2 hours) | $23.40/hr | $46.80
+04_102_0136_6_1
+Provider travel - labour | 11/01/23 | 30 minutes | $23.40/hr | $11.70
+costs
+04_102_0136_6_1
+Provider travel - non-labour | 11/01/23 | 15 km | $0.28/km | $4.20
+costs
+04_799_0136_6_1
+Total | $69.96
+Marlee Provider
+ABN: 12 345 678 901
+Bank: Sample Bank
+BSB: 123-456
+Account Number: 987 654 321

--- a/src/lib/activity-utils.test.ts
+++ b/src/lib/activity-utils.test.ts
@@ -222,7 +222,8 @@ test("Should include activity based transport items in total", () => {
 		])
 	).toEqual(77.25); // 55.47 + 22 * 0.99
 
-	// DISTANCE group: km * 0.49
+	// DISTANCE group (N=2, docs/plans/016): support and ABT both apportioned
+	// by group size — floorToCent(55.47/2) + 22 * floorToCent(0.99/2)
 	expect(
 		getTotalCostOfActivities([
 			{
@@ -230,7 +231,7 @@ test("Should include activity based transport items in total", () => {
 				transportItems: [{ type: "DISTANCE" as const, amount: 22 }]
 			}
 		])
-	).toEqual(66.25); // 55.47 + 22 * 0.49
+	).toEqual(38.51); // 27.73 + 22 * 0.49
 
 	// PARKING / TOLL / OTHER are flat amounts
 	expect(
@@ -354,9 +355,9 @@ test("Should resolve transit rate with correct precedence", () => {
 });
 
 test("Group branch beats a client transit rate override", () => {
-	// Group activities always bill transit at GROUP_TRANSIT_RATE, even when
-	// the client has a custom transitRatePerKm — until plan 016 replaces the
-	// constant with effective-rate ÷ group-size
+	// Group transit still resolves client → user → default first (docs/plans/016);
+	// the client override wins over both the rateContext and the 0.99 default,
+	// then the effective rate is apportioned by group size (N=2 default).
 	const groupActivityWithClientOverride = {
 		...getActivity("weekday", "16:00", "17:00", 0, 10, true),
 		client: { transitRatePerKm: new Prisma.Decimal(0.5) }
@@ -366,60 +367,61 @@ test("Group branch beats a client transit rate override", () => {
 		getTotalCostOfActivities([groupActivityWithClientOverride], {
 			userTransitRatePerKm: 0.85
 		})
-	).toEqual(59.77); // 55.47 + 10 * 0.43 (GROUP_TRANSIT_RATE, not 0.5 or 0.85)
+	).toEqual(30.23); // floorToCent(55.47/2) + 10 * floorToCent(0.5/2)
 });
 
 test("Should return correct total for group activities", () => {
-	// Group activities price transit distance at the group rate ($0.43/km),
-	// matching the PDF's non-labour travel line items
+	// Group activities apportion every rate category by group size (N=2
+	// default when unset) — hourly support/labour-travel and transit per-km
+	// (docs/plans/016). Support rate: floorToCent(55.47/2) = 27.73.
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "16:00", "17:00", 0, 0, true)
 		])
-	).toEqual(55.47);
+	).toEqual(27.73);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "15:00", "17:00", 7, 15, true)
 		])
-	).toEqual(123.86);
+	).toEqual(66.05);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "15:00", "17:00", 7, 15, true),
 			getActivity("weekday", "15:00", "21:00", 7, 15, true)
 		])
-	).toEqual(503.73);
+	).toEqual(260.08);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("saturday", "15:00", "17:00", 7, 15, true)
 		])
-	).toEqual(171.15);
+	).toEqual(89.69);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("saturday", "19:00", "21:00", 7, 15, true)
 		])
-	).toEqual(171.15);
+	).toEqual(89.69);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "09:30", "15:00", 0, 0, true)
 		])
-	).toEqual(305.09);
+	).toEqual(152.52);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "09:30", "15:10", 0, 0, true)
 		])
-	).toEqual(314.33);
+	).toEqual(157.14);
 
 	expect(
 		getTotalCostOfActivities([
 			getActivity("weekday", "16:10", "20:10", 0, 0, true)
 		])
-	).toEqual(244.2);
+	).toEqual(122.08);
 
 	expect(
 		getTotalCostOfActivities([
@@ -427,7 +429,7 @@ test("Should return correct total for group activities", () => {
 			getActivity("weekday", "09:30", "15:10", 15, 7, true),
 			getActivity("weekday", "09:30", "15:23", 15, 7, true)
 		])
-	).toEqual(996.41);
+	).toEqual(503.88);
 
 	expect(
 		getTotalCostOfActivities([
@@ -439,5 +441,5 @@ test("Should return correct total for group activities", () => {
 			getActivity("weekday", "09:30", "15:10", 15, 7, true),
 			getActivity("weekday", "09:30", "15:25", 15, 7, true)
 		])
-	).toEqual(2295.38);
+	).toEqual(1160.95);
 });

--- a/src/lib/billing-lines.test.ts
+++ b/src/lib/billing-lines.test.ts
@@ -62,7 +62,22 @@ test("group activity's ABT DISTANCE lines at 0.49/km", () => {
 	expect(abtLine?.total).toEqual(round(10 * 0.49, 2));
 });
 
-test("group activity's TRAVEL_KM line bills at the group rate (0.43/km), via getTransitRate", () => {
+test("group activity's TRAVEL_KM line apportions the effective rate by group size (docs/plans/016)", () => {
+	const lines = billableLines(
+		{
+			...fullyLoadedActivity,
+			transportItems: [],
+			supportItem: { ...baseSupportItem, isGroup: true }
+		},
+		{ userTransitRatePerKm: 0.85 }
+	);
+
+	const travelKmLine = lines.find((line) => line.kind === "TRAVEL_KM");
+	expect(travelKmLine?.unitPrice).toEqual(0.42); // floorToCent(0.85 / 2)
+	expect(travelKmLine?.total).toEqual(round(15 * 0.42, 2));
+});
+
+test("group activity with no groupSize defaults to N=2", () => {
 	const lines = billableLines({
 		...fullyLoadedActivity,
 		transportItems: [],
@@ -70,8 +85,50 @@ test("group activity's TRAVEL_KM line bills at the group rate (0.43/km), via get
 	});
 
 	const travelKmLine = lines.find((line) => line.kind === "TRAVEL_KM");
-	expect(travelKmLine?.unitPrice).toEqual(0.43);
-	expect(travelKmLine?.total).toEqual(round(15 * 0.43, 2));
+	expect(travelKmLine?.unitPrice).toEqual(0.49); // floorToCent(0.99 / 2)
+});
+
+test("group activity rates apportion by an explicit groupSize (N=3, N=10)", () => {
+	const supportItem = { ...baseSupportItem, isGroup: true };
+
+	const n3 = billableLines({
+		...fullyLoadedActivity,
+		groupSize: 3,
+		supportItem
+	});
+	expect(n3.find((line) => line.kind === "SUPPORT")?.unitPrice).toEqual(
+		18.49 // floorToCent(55.47 / 3)
+	);
+	expect(n3.find((line) => line.kind === "TRAVEL_KM")?.unitPrice).toEqual(
+		0.33 // floorToCent(0.99 / 3)
+	);
+	expect(n3.find((line) => line.kind === "ABT")?.unitPrice).toEqual(
+		0.33 // floorToCent(0.99 / 3)
+	);
+
+	const n10 = billableLines({
+		...fullyLoadedActivity,
+		groupSize: 10,
+		supportItem
+	});
+	expect(n10.find((line) => line.kind === "TRAVEL_KM")?.unitPrice).toEqual(
+		0.09 // floorToCent(0.99 / 10)
+	);
+	expect(n10.find((line) => line.kind === "ABT")?.unitPrice).toEqual(
+		0.09 // floorToCent(0.99 / 10)
+	);
+});
+
+test("non-group activity is unaffected by groupSize apportioning", () => {
+	const lines = billableLines({ ...fullyLoadedActivity, groupSize: 5 });
+
+	expect(lines.find((line) => line.kind === "SUPPORT")?.unitPrice).toEqual(
+		55.47
+	);
+	expect(lines.find((line) => line.kind === "TRAVEL_KM")?.unitPrice).toEqual(
+		0.99
+	);
+	expect(lines.find((line) => line.kind === "ABT")?.unitPrice).toEqual(0.99);
 });
 
 test("solo activity's TRAVEL_KM line resolves the plan-006 effective rate (client → user → 0.99)", () => {

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -9,7 +9,7 @@ import type {
 	SupportItemRates
 } from "@/generated/client";
 import { getDuration } from "./date-utils";
-import { round } from "./generic-utils";
+import { floorToCent, round } from "./generic-utils";
 import {
 	getActivityBasedTransportCode,
 	getNonLabourTravelCode
@@ -33,6 +33,7 @@ export interface BillableActivity {
 	itemDistance?: number | null;
 	transitDistance?: Prisma.Decimal | null;
 	transitDuration?: Prisma.Decimal | null;
+	groupSize?: number | null;
 	transportItems?: TransportItem[];
 	supportItem: Pick<
 		SupportItem,
@@ -64,13 +65,16 @@ export interface TransitRateContext {
 
 const DEFAULT_TRANSIT_RATE = 0.99;
 
-// TODO: Handle groups other than 2 clients
-const GROUP_TRANSIT_RATE = 0.43;
-
 const DEFAULT_ACTIVITY_TRANSPORT_RATE = 0.99;
 
-// TODO: Handle groups other than 2 clients
-const GROUP_ACTIVITY_TRANSPORT_RATE = 0.49;
+/**
+ * The number of participants a group activity's rate is divided across.
+ * Defaults to 2 for group activities created before `groupSize` existed
+ * (docs/plans/016). Non-group activities always have a single participant.
+ */
+export function groupSizeOf(activity: BillableActivity): number {
+	return activity.supportItem.isGroup ? (activity.groupSize ?? 2) : 1;
+}
 
 const getRateForDay = (
 	day: "weekday" | "weeknight" | "saturday" | "sunday",
@@ -148,20 +152,21 @@ export const getRateForActivity = (
 	return [activity.supportItem.weekdayCode, Number(rate)];
 };
 
-/** The effective non-labour travel rate per km: group → client → user → default. */
+/** The effective non-labour travel rate per km: client → user → default, apportioned by group size. */
 export function getTransitRate(
 	activity: BillableActivity,
 	rateContext?: TransitRateContext
 ): number {
-	if (activity.supportItem.isGroup) {
-		return GROUP_TRANSIT_RATE;
-	}
-
-	return (
+	const effectiveRate =
 		Number(activity.client?.transitRatePerKm) ||
 		rateContext?.userTransitRatePerKm ||
-		DEFAULT_TRANSIT_RATE
-	);
+		DEFAULT_TRANSIT_RATE;
+
+	if (activity.supportItem.isGroup) {
+		return floorToCent(effectiveRate / groupSizeOf(activity));
+	}
+
+	return effectiveRate;
 }
 
 export type LineKind =
@@ -198,7 +203,12 @@ export function billableLines(
 	rateContext?: TransitRateContext
 ): BillableLine[] {
 	const lines: BillableLine[] = [];
-	const [itemCode, rate] = getRateForActivity(activity);
+	const [itemCode, resolvedRate] = getRateForActivity(activity);
+	// Apportioned once so the support line, its printed unit price, and the
+	// labour-travel rate/60 all use the same per-participant figure.
+	const rate = activity.supportItem.isGroup
+		? floorToCent(resolvedRate / groupSizeOf(activity))
+		: resolvedRate;
 
 	// SUPPORT: gated on rateType like the PDF (the printed truth), not on
 	// which fields happen to be populated. A KM-rate item always bills by
@@ -283,9 +293,8 @@ export function billableLines(
 
 	// Activity Based Transport items
 	if (activity.transportItems) {
-		const isGroup = activity.supportItem.isGroup;
-		const activityTransportRate = isGroup
-			? GROUP_ACTIVITY_TRANSPORT_RATE
+		const activityTransportRate = activity.supportItem.isGroup
+			? floorToCent(DEFAULT_ACTIVITY_TRANSPORT_RATE / groupSizeOf(activity))
 			: DEFAULT_ACTIVITY_TRANSPORT_RATE;
 		const transportCode =
 			getActivityBasedTransportCode(activity.supportItem.weekdayCode) ?? "";

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -76,6 +76,18 @@ export function groupSizeOf(activity: BillableActivity): number {
 	return activity.supportItem.isGroup ? (activity.groupSize ?? 2) : 1;
 }
 
+/**
+ * A group activity's per-participant share of `rate`, floored to the cent so
+ * the summed claim across participants never exceeds the base (docs/plans/016).
+ * The full rate for non-group activities. This is the single place the isGroup
+ * gate and the floor policy live — every apportioned rate goes through here.
+ */
+function apportion(rate: number, activity: BillableActivity): number {
+	return activity.supportItem.isGroup
+		? floorToCent(rate / groupSizeOf(activity))
+		: rate;
+}
+
 const getRateForDay = (
 	day: "weekday" | "weeknight" | "saturday" | "sunday",
 	supportItem: BillableActivity["supportItem"],
@@ -162,11 +174,7 @@ export function getTransitRate(
 		rateContext?.userTransitRatePerKm ||
 		DEFAULT_TRANSIT_RATE;
 
-	if (activity.supportItem.isGroup) {
-		return floorToCent(effectiveRate / groupSizeOf(activity));
-	}
-
-	return effectiveRate;
+	return apportion(effectiveRate, activity);
 }
 
 export type LineKind =
@@ -206,9 +214,7 @@ export function billableLines(
 	const [itemCode, resolvedRate] = getRateForActivity(activity);
 	// Apportioned once so the support line, its printed unit price, and the
 	// labour-travel rate/60 all use the same per-participant figure.
-	const rate = activity.supportItem.isGroup
-		? floorToCent(resolvedRate / groupSizeOf(activity))
-		: resolvedRate;
+	const rate = apportion(resolvedRate, activity);
 
 	// SUPPORT: gated on rateType like the PDF (the printed truth), not on
 	// which fields happen to be populated. A KM-rate item always bills by
@@ -293,9 +299,10 @@ export function billableLines(
 
 	// Activity Based Transport items
 	if (activity.transportItems) {
-		const activityTransportRate = activity.supportItem.isGroup
-			? floorToCent(DEFAULT_ACTIVITY_TRANSPORT_RATE / groupSizeOf(activity))
-			: DEFAULT_ACTIVITY_TRANSPORT_RATE;
+		const activityTransportRate = apportion(
+			DEFAULT_ACTIVITY_TRANSPORT_RATE,
+			activity
+		);
 		const transportCode =
 			getActivityBasedTransportCode(activity.supportItem.weekdayCode) ?? "";
 

--- a/src/lib/generic-utils.test.ts
+++ b/src/lib/generic-utils.test.ts
@@ -1,4 +1,4 @@
-import { pickRandomFrom, round } from "@/lib/generic-utils";
+import { floorToCent, pickRandomFrom, round } from "@/lib/generic-utils";
 import { expect, test } from "vitest";
 
 const testArr = ["first", "second", "third", "fourth", "fifth"];
@@ -25,4 +25,12 @@ test("Should round correctly", () => {
 	expect(round(1.55, 1)).toEqual(1.6);
 	expect(round(1.5, 0)).toEqual(2);
 	expect(round(305.085, 2)).toEqual(305.09);
+});
+
+test("Should floor to the nearest cent", () => {
+	expect(floorToCent(0.99 / 2)).toEqual(0.49);
+	expect(floorToCent(0.85 / 2)).toEqual(0.42);
+	expect(floorToCent(70.2 / 2)).toEqual(35.1);
+	expect(floorToCent(0.99 / 3)).toEqual(0.33);
+	expect(floorToCent(0.99 / 10)).toEqual(0.09);
 });

--- a/src/lib/generic-utils.ts
+++ b/src/lib/generic-utils.ts
@@ -15,6 +15,15 @@ export function round(value: number, exp: number) {
 	return +`${valueArray[0]}e${valueArray[1] ? +valueArray[1] - exp : -exp}`;
 }
 
+/**
+ * Floors a dollar value to the nearest cent, neutralising float noise first
+ * (e.g. 70.2 / 2 === 35.099999999999994 in IEEE 754) so a genuine exact
+ * division isn't floored down a cent by representation error.
+ */
+export function floorToCent(value: number): number {
+	return Math.floor(round(value * 100, 6)) / 100;
+}
+
 export function groupBy<T>(arr: T[], keyGetter: (item: T) => string) {
 	const groupedObj: { [key: string]: T[] } = {};
 

--- a/src/lib/group-participants.ts
+++ b/src/lib/group-participants.ts
@@ -1,0 +1,28 @@
+import { MAX_ADDITIONAL_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
+
+/**
+ * The add/update/remove transforms for a group activity's "other participants"
+ * list. Both participant editors — the quick-entry multi-activity form and the
+ * invoice creation form — drive their `string[]` of client ids through these,
+ * so the shape of the list (and the max-participant cap) lives in one place.
+ * Each returns a new array; the caller owns where that value is persisted.
+ */
+
+/** Replace the participant client id at `index`. */
+export const setParticipantAt = (
+	ids: string[],
+	index: number,
+	clientId: string
+): string[] => {
+	const next = [...ids];
+	next[index] = clientId;
+	return next;
+};
+
+/** Append an empty participant slot, capped at the max additional participants. */
+export const appendParticipant = (ids: string[]): string[] =>
+	ids.length >= MAX_ADDITIONAL_GROUP_PARTICIPANTS ? ids : [...ids, ""];
+
+/** Remove the participant at `index`. */
+export const removeParticipantAt = (ids: string[], index: number): string[] =>
+	ids.filter((_, i) => i !== index);

--- a/src/lib/pdf-generation.text.test.ts
+++ b/src/lib/pdf-generation.text.test.ts
@@ -62,9 +62,10 @@ const invariants: Record<string, { contains: string[]; excludes?: string[] }> =
 		},
 		"transit-group": {
 			// The 0136 (group) registration group derives the group non-labour
-			// travel code, billed at $0.43/km on the line item AND in the Total
-			// (Q1 fixed: both now go through getTransitRate)
-			contains: ["04_799_0136_6_1", "$0.43/km", "$6.45", "$161.88"]
+			// travel code, billed at the apportioned rate (docs/plans/016:
+			// floorToCent(the fixture user's 0.85/km ÷ 2) = $0.42/km) on the line
+			// item AND in the Total (Q1 fixed: both now go through getTransitRate)
+			contains: ["04_799_0136_6_1", "$0.42/km", "$6.30", "$161.73"]
 		},
 		"transport-all-types": {
 			contains: [
@@ -83,6 +84,21 @@ const invariants: Record<string, { contains: string[]; excludes?: string[] }> =
 		},
 		"transport-group-distance": {
 			contains: ["04_591_0136_6_1", "$0.49/km", "$10.78", "$135.12"]
+		},
+		"transport-group-three-participants": {
+			// N=3 apportioning (docs/plans/016): floorToCent(70.2/3) = $23.40/hr,
+			// floorToCent(0.85/3) = $0.28/km transit, floorToCent(0.99/3) = $0.33/km ABT
+			contains: [
+				"04_591_0136_6_1",
+				"04_799_0136_6_1",
+				"$0.33/km",
+				"$7.26",
+				"$23.40/hr",
+				"$46.80",
+				"$0.28/km",
+				"$4.20",
+				"$69.96"
+			]
 		},
 		"duplicate-merge": { contains: ["$186.51"] },
 		"kitchen-sink": {
@@ -134,12 +150,15 @@ const invariants: Record<string, { contains: string[]; excludes?: string[] }> =
 				"04_799_0136_6_1",
 				"13:20-14:25 (1 hour, 5 mins)",
 				"$0.49/km",
-				"$0.43/km",
+				// docs/plans/016: the group's non-labour travel apportions the
+				// fixture user's 0.85/km rate by group size — floorToCent(0.85/2)
+				"$0.42/km",
 				// The source invoice printed $1168.15 ($7.28 above its line-item
-				// sum — quirk Q1); with Q1 fixed the Total equals the line items.
-				// Once the user's 0.85 rate is threaded through (this plan), the
-				// two solo travel legs drop from $0.99/km to $0.85/km.
-				"$1153.59"
+				// sum — quirk Q1); with Q1 fixed and the user's 0.85 rate threaded
+				// through, the Total was $1153.59. docs/plans/016's deliberate
+				// -1c/km transit apportioning change (13km × $0.01) brings it to
+				// $1153.46.
+				"$1153.46"
 			]
 		}
 	};

--- a/src/lib/testing/invoice-fixtures.ts
+++ b/src/lib/testing/invoice-fixtures.ts
@@ -635,10 +635,11 @@ const recurringSlot = (() => {
  * 0125 codes ($0.99/km); odd durations (1h 5m, 5h 30m, 4h 5m); provider
  * travel labour billed per minute at each parent item's rate; and both
  * Participant Number and Bill To in the header. The source invoice printed a
- * Total of $1168.15 — $7.28 above its own line-item sum — because it exhibited
+ * Total of $1168.15 that ran above its own line-item sum because it exhibited
  * quirk Q1 (the Total charged the group's 13 km at $0.99/km instead of the
- * group rate). With Q1 fixed, the Total was $1160.87; docs/plans/016's
- * deliberate -1c/km transit apportioning change brings it to $1160.74.
+ * group rate). With Q1 fixed the Total matches its line-item sum; docs/plans/016's
+ * deliberate -1c/km transit apportioning — the group's 13 km moving from $0.43
+ * to $0.42/km — trims a further $0.13 to reach the current golden $1153.46.
  * (The original paginated onto page 2; with the price guide's shorter item
  * names the table now fits on one page.)
  */

--- a/src/lib/testing/invoice-fixtures.ts
+++ b/src/lib/testing/invoice-fixtures.ts
@@ -128,6 +128,11 @@ const makeSupportItem = (
  * registration group, which derives the group travel/transport codes
  * (04_591_0136_6_1, 04_799_0136_6_1). Price limits in the 22-23 catalogue
  * are identical to the solo 0125 item's.
+ *
+ * Rates are the FULL-SESSION amount (docs/plans/016 operator decision 3):
+ * double the solo item's per-participant rate, so that billing's ÷2
+ * apportioning (the fixtures' default `groupSize`) reproduces the exact
+ * solo-equivalent per-participant cents.
  */
 const makeGroupSupportItem = (
 	fixtureName: string,
@@ -140,6 +145,10 @@ const makeGroupSupportItem = (
 		weeknightCode: "04_103_0136_6_1",
 		saturdayCode: "04_104_0136_6_1",
 		sundayCode: "04_105_0136_6_1",
+		weekdayRate: new Prisma.Decimal(124.34),
+		weeknightRate: new Prisma.Decimal(137),
+		saturdayRate: new Prisma.Decimal(175.02),
+		sundayRate: new Prisma.Decimal(225.7),
 		...overrides
 	});
 
@@ -187,6 +196,7 @@ const makeActivity = (
 	transitDuration: null,
 	transitDistance: null,
 	itemDistance: null,
+	groupSize: null,
 	ownerId: `user_${fixtureName}`,
 	clientId: `client_${fixtureName}`,
 	supportItemId: `supportitem_${fixtureName}`,
@@ -333,9 +343,10 @@ const transitSolo = makeFixture(
 
 /**
  * 8. Group provider travel: the non-labour line item and the printed Total
- * both price transit at the group rate ($0.43/km) via getTransitRate, so the
+ * both price transit at the apportioned group rate ($0.42/km = floorToCent(the
+ * fixture user's 0.85/km ÷ 2), docs/plans/016) via getTransitRate, so the
  * Total equals the sum of the line items. (Formerly quirk Q1: the Total
- * charged $0.99/km while the line item showed $0.43/km.)
+ * charged $0.99/km while the line item showed a hardcoded $0.43/km.)
  */
 const transitGroup = makeFixture(
 	"transit-group",
@@ -343,6 +354,7 @@ const transitGroup = makeFixture(
 		makeActivity("transit-group", 1, {
 			transitDuration: new Prisma.Decimal(30),
 			transitDistance: new Prisma.Decimal(15),
+			groupSize: 2,
 			supportItem: makeGroupSupportItem("transit-group")
 		})
 	])
@@ -392,8 +404,35 @@ const transportGroupDistance = makeFixture(
 	makeInvoice("transport-group-distance", "TRANSPORT-2", [
 		makeActivity("transport-group-distance", 1, {
 			supportItem: makeGroupSupportItem("transport-group-distance"),
+			groupSize: 2,
 			transportItems: [
 				makeTransportItem("transport-group-distance", 1, {
+					type: ActivityTransportType.DISTANCE,
+					amount: new Prisma.Decimal(22)
+				})
+			]
+		})
+	])
+);
+
+/**
+ * 10a. A 3-participant group activity (docs/plans/016) — every category
+ * apportions by 3 instead of the N=2 default: hourly floorToCent(70.2/3) =
+ * 23.40/hr, transit floorToCent(0.85/3) = 0.28/km, ABT floorToCent(0.99/3) =
+ * 0.33/km.
+ */
+const transportGroupThreeParticipants = makeFixture(
+	"transport-group-three-participants",
+	makeInvoice("transport-group-three-participants", "GROUP3-1", [
+		makeActivity("transport-group-three-participants", 1, {
+			supportItem: makeGroupSupportItem("transport-group-three-participants", {
+				weekdayRate: new Prisma.Decimal(70.2)
+			}),
+			groupSize: 3,
+			transitDuration: new Prisma.Decimal(30),
+			transitDistance: new Prisma.Decimal(15),
+			transportItems: [
+				makeTransportItem("transport-group-three-participants", 1, {
 					type: ActivityTransportType.DISTANCE,
 					amount: new Prisma.Decimal(22)
 				})
@@ -591,13 +630,15 @@ const recurringSlot = (() => {
 /**
  * 16. The richest real-world shape, plan-managed: a group session whose 0136
  * registration group derives 04_591_0136_6_1 transport ($0.49/km) and
- * 04_799_0136_6_1 non-labour travel ($0.43/km), alongside solo sessions on
+ * 04_799_0136_6_1 non-labour travel (apportioned to $0.42/km, docs/plans/016 —
+ * floorToCent(the fixture user's 0.85/km ÷ 2)), alongside solo sessions on
  * 0125 codes ($0.99/km); odd durations (1h 5m, 5h 30m, 4h 5m); provider
  * travel labour billed per minute at each parent item's rate; and both
  * Participant Number and Bill To in the header. The source invoice printed a
  * Total of $1168.15 — $7.28 above its own line-item sum — because it exhibited
- * quirk Q1 (the Total charged the group's 13 km at $0.99/km instead of
- * $0.43/km). With Q1 fixed, the Total is $1160.87, equal to the line items.
+ * quirk Q1 (the Total charged the group's 13 km at $0.99/km instead of the
+ * group rate). With Q1 fixed, the Total was $1160.87; docs/plans/016's
+ * deliberate -1c/km transit apportioning change brings it to $1160.74.
  * (The original paginated onto page 2; with the price guide's shorter item
  * names the table now fits on one page.)
  */
@@ -606,12 +647,13 @@ const planManagedWeek = (() => {
 	const communityAccess = makeCommunityAccessItem(name);
 	const groupActivities = makeGroupSupportItem(name, {
 		id: `supportitem_${name}_group`,
-		// The real user's group item is weekday-only, at their apportioned
-		// (per-participant) rate rather than the full published price limit
+		// The real user's group item is weekday-only, at the full-session rate
+		// (docs/plans/016) rather than the full published price limit — 70.20
+		// apportions to the pre-plan per-participant rate of 35.10 at N=2.
 		weeknightCode: null,
 		saturdayCode: null,
 		sundayCode: null,
-		weekdayRate: new Prisma.Decimal(35.1),
+		weekdayRate: new Prisma.Decimal(70.2),
 		weeknightRate: null,
 		saturdayRate: null,
 		sundayRate: null
@@ -631,6 +673,7 @@ const planManagedWeek = (() => {
 					endTime: time("13:20"),
 					supportItemId: `supportitem_${name}_group`,
 					supportItem: groupActivities,
+					groupSize: 2,
 					transitDuration: new Prisma.Decimal(25),
 					transitDistance: new Prisma.Decimal(13),
 					transportItems: [
@@ -701,6 +744,7 @@ export const invoiceFixtures: InvoiceFixture[] = [
 	transitGroup,
 	transportAllTypes,
 	transportGroupDistance,
+	transportGroupThreeParticipants,
 	duplicateMerge,
 	kitchenSink,
 	noPaymentFooter,

--- a/src/schema/activity-schema.ts
+++ b/src/schema/activity-schema.ts
@@ -29,7 +29,8 @@ export const activitySchema = z
 		itemDistance: z.number(),
 		transitDistance: z.string().optional(),
 		transitDuration: z.string().optional(),
-		transportItems: z.array(activityTransportItemSchema).optional()
+		transportItems: z.array(activityTransportItemSchema).optional(),
+		groupSize: z.number().int().min(2).max(10).optional()
 	})
 	.partial({ startTime: true, endTime: true, itemDistance: true })
 	.refine(

--- a/src/schema/invoice-schema.ts
+++ b/src/schema/invoice-schema.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
-/** A group activity's primary client plus up to this many other participants (10 total). */
-export const MAX_GROUP_PARTICIPANTS = 9;
+/** The most *other* participants a group activity can add to its primary client (10 total). */
+export const MAX_ADDITIONAL_GROUP_PARTICIPANTS = 9;
+
+/** Total participants sharing a group session: the primary client plus the other participants. */
+export const totalGroupSize = (otherParticipantIds: string[]): number =>
+	otherParticipantIds.length + 1;
 
 export const invoiceSchema = z.object({
 	date: z.date().optional(),
@@ -14,7 +18,7 @@ export const invoiceSchema = z.object({
 			supportItemId: z.string().min(1, "Support item is required"),
 			groupClientIds: z
 				.array(z.string())
-				.max(MAX_GROUP_PARTICIPANTS)
+				.max(MAX_ADDITIONAL_GROUP_PARTICIPANTS)
 				.default([]),
 			activities: z.array(
 				z

--- a/src/schema/invoice-schema.ts
+++ b/src/schema/invoice-schema.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/** A group activity's primary client plus up to this many other participants (10 total). */
+export const MAX_GROUP_PARTICIPANTS = 9;
+
 export const invoiceSchema = z.object({
 	date: z.date().optional(),
 	clientId: z.string().min(1, "Client is required"),
@@ -9,7 +12,10 @@ export const invoiceSchema = z.object({
 	activitiesToCreate: z.array(
 		z.object({
 			supportItemId: z.string().min(1, "Support item is required"),
-			groupClientId: z.string(),
+			groupClientIds: z
+				.array(z.string())
+				.max(MAX_GROUP_PARTICIPANTS)
+				.default([]),
 			activities: z.array(
 				z
 					.object({

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -341,6 +341,27 @@ export const activityRouter = router({
 				return { activities: [], tripId: null };
 			}
 
+			const groupSizeSupportItemIds = [
+				...new Set(
+					inputActivities
+						.filter((activity) => activity.groupSize !== undefined)
+						.map((activity) => activity.supportItemId)
+				)
+			];
+
+			if (groupSizeSupportItemIds.length > 0) {
+				const groupSupportItems = await ctx.owned.supportItem.findMany({
+					where: { id: { in: groupSizeSupportItemIds }, isGroup: true }
+				});
+
+				if (groupSupportItems.length !== groupSizeSupportItemIds.length) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "groupSize can only be set for group support items"
+					});
+				}
+			}
+
 			// Parse and validate all activities
 			const parsedActivities = inputActivities.map((activity) => {
 				const { transportItems, ...activityData } = activity;
@@ -374,6 +395,7 @@ export const activityRouter = router({
 							supportItemId: activity.supportItemId,
 							transitDistance: activity.transitDistance || undefined,
 							transitDuration: activity.transitDuration || undefined,
+							groupSize: activity.groupSize,
 							ownerId: ctx.session.user.id,
 							transportItems:
 								activity.transportItems && activity.transportItems.length > 0

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -47,18 +47,24 @@ const generateNestedWriteForActivities = (
 	client: Client,
 	ownerId: string
 ) => ({
-	data: activitiesToCreate.flatMap(({ supportItemId, activities }) =>
-		activities.map((activity) => ({
-			...activity,
-			date: activity.date,
-			startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
-			endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
-			clientId: client.id,
-			transitDistance: client.distanceToClient ?? undefined,
-			transitDuration: client.travelTimeToClient ?? undefined,
-			supportItemId,
-			ownerId
-		}))
+	data: activitiesToCreate.flatMap(
+		({ supportItemId, groupClientIds, activities }) => {
+			const groupSize =
+				groupClientIds.length > 0 ? groupClientIds.length + 1 : undefined;
+
+			return activities.map((activity) => ({
+				...activity,
+				date: activity.date,
+				startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
+				endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
+				clientId: client.id,
+				transitDistance: client.distanceToClient ?? undefined,
+				transitDuration: client.travelTimeToClient ?? undefined,
+				supportItemId,
+				groupSize,
+				ownerId
+			}));
+		}
 	)
 });
 
@@ -68,20 +74,25 @@ const generateNestedWriteForGroupActivities = (
 	clients: Client[]
 ) => ({
 	data: activitiesToCreate.flatMap(
-		({ supportItemId, groupClientId, activities }) => {
-			const client = clients.find((c) => c.id === groupClientId);
+		({ supportItemId, groupClientIds, activities }) => {
+			const groupSize = groupClientIds.length + 1;
 
-			return activities.map((activity) => ({
-				...activity,
-				supportItemId,
-				date: activity.date,
-				startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
-				endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
-				clientId: groupClientId,
-				transitDistance: client?.distanceToClient ?? undefined,
-				transitDuration: client?.travelTimeToClient ?? undefined,
-				ownerId
-			}));
+			return groupClientIds.flatMap((groupClientId) => {
+				const client = clients.find((c) => c.id === groupClientId);
+
+				return activities.map((activity) => ({
+					...activity,
+					supportItemId,
+					date: activity.date,
+					startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
+					endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
+					clientId: groupClientId,
+					transitDistance: client?.distanceToClient ?? undefined,
+					transitDuration: client?.travelTimeToClient ?? undefined,
+					groupSize,
+					ownerId
+				}));
+			});
 		}
 	)
 });
@@ -229,6 +240,29 @@ export const invoiceRouter = router({
 				);
 			}
 
+			const soloRowSupportItemIds = [
+				...new Set(
+					inputInvoice.activitiesToCreate
+						.filter((activity) => activity.groupClientIds.length === 0)
+						.map((activity) => activity.supportItemId)
+				)
+			];
+
+			if (soloRowSupportItemIds.length > 0) {
+				const groupSupportItemsAmongSoloRows =
+					await ctx.owned.supportItem.findMany({
+						where: { id: { in: soloRowSupportItemIds }, isGroup: true },
+						select: { id: true }
+					});
+
+				if (groupSupportItemsAmongSoloRows.length > 0) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Group activities require at least one other participant"
+					});
+				}
+			}
+
 			const invoice = await ctx.prisma.invoice.create({
 				data: {
 					invoiceNo: inputInvoice.invoiceNo,
@@ -252,22 +286,42 @@ export const invoiceRouter = router({
 			}
 
 			const groupActivitiesToCreate = inputInvoice.activitiesToCreate.filter(
-				(activity) => activity.groupClientId
+				(activity) => activity.groupClientIds.length > 0
 			);
-			if (groupActivitiesToCreate) {
-				const groupClientIds = groupActivitiesToCreate.map(
-					(activity) => activity.groupClientId
+
+			if (groupActivitiesToCreate.length > 0) {
+				for (const activity of groupActivitiesToCreate) {
+					if (
+						new Set(activity.groupClientIds).size !==
+						activity.groupClientIds.length
+					) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: "Group participants must be distinct"
+						});
+					}
+
+					if (activity.groupClientIds.includes(inputInvoice.clientId)) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: "The primary client cannot also be a group participant"
+						});
+					}
+				}
+
+				const allGroupClientIds = groupActivitiesToCreate.flatMap(
+					(activity) => activity.groupClientIds
 				);
 
 				const clients = await ctx.owned.client.findMany({
 					where: {
 						id: {
-							in: groupClientIds
+							in: allGroupClientIds
 						}
 					}
 				});
 
-				if (clients.length !== new Set(groupClientIds).size) {
+				if (clients.length !== new Set(allGroupClientIds).size) {
 					throw new TRPCError({
 						code: "NOT_FOUND",
 						message: "One or more group clients not found"

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -2,10 +2,19 @@ import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { invoiceCandidatesFromPaymentAmount } from "@/lib/invoice-utils";
 import { baseListQueryInput } from "@/lib/trpc";
 import { activitySchema } from "@/schema/activity-schema";
-import { InvoiceSchema, invoiceSchema } from "@/schema/invoice-schema";
-import { paginate } from "@/server/api/owned";
+import {
+	InvoiceSchema,
+	invoiceSchema,
+	totalGroupSize
+} from "@/schema/invoice-schema";
+import { ownedDb, paginate } from "@/server/api/owned";
 import { authedProcedure, router } from "@/server/api/trpc";
-import { Client, Invoice, InvoiceStatus } from "@/generated/client";
+import {
+	Client,
+	Invoice,
+	InvoiceStatus,
+	PrismaClient
+} from "@/generated/client";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
 import dayjs from "dayjs";
 import { z } from "zod";
@@ -50,7 +59,7 @@ const generateNestedWriteForActivities = (
 	data: activitiesToCreate.flatMap(
 		({ supportItemId, groupClientIds, activities }) => {
 			const groupSize =
-				groupClientIds.length > 0 ? groupClientIds.length + 1 : undefined;
+				groupClientIds.length > 0 ? totalGroupSize(groupClientIds) : undefined;
 
 			return activities.map((activity) => ({
 				...activity,
@@ -75,7 +84,7 @@ const generateNestedWriteForGroupActivities = (
 ) => ({
 	data: activitiesToCreate.flatMap(
 		({ supportItemId, groupClientIds, activities }) => {
-			const groupSize = groupClientIds.length + 1;
+			const groupSize = totalGroupSize(groupClientIds);
 
 			return groupClientIds.flatMap((groupClientId) => {
 				const client = clients.find((c) => c.id === groupClientId);
@@ -96,6 +105,101 @@ const generateNestedWriteForGroupActivities = (
 		}
 	)
 });
+
+type GroupWriteCtx = {
+	owned: ReturnType<typeof ownedDb>;
+	prisma: PrismaClient;
+};
+
+/**
+ * Guard: a group support item on a row with no other participants can't be
+ * billed (its rate would divide by 1). Both create and modify enforce this.
+ */
+const assertGroupRowsHaveParticipants = async (
+	owned: GroupWriteCtx["owned"],
+	activitiesToCreate: InvoiceSchema["activitiesToCreate"]
+) => {
+	const soloRowSupportItemIds = [
+		...new Set(
+			activitiesToCreate
+				.filter((activity) => activity.groupClientIds.length === 0)
+				.map((activity) => activity.supportItemId)
+		)
+	];
+
+	if (soloRowSupportItemIds.length === 0) return;
+
+	const groupSupportItemsAmongSoloRows = await owned.supportItem.findMany({
+		where: { id: { in: soloRowSupportItemIds }, isGroup: true },
+		select: { id: true }
+	});
+
+	if (groupSupportItemsAmongSoloRows.length > 0) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Group activities require at least one other participant"
+		});
+	}
+};
+
+/**
+ * Validate group rows and fan out one mirrored (pending) activity per other
+ * participant. Shared by create and modify so the invoice edit flow — which
+ * renders the same participant UI — can't persist a group primary with a
+ * `groupSize` but no sibling activities.
+ */
+const createGroupMirrorActivities = async (
+	ctx: GroupWriteCtx,
+	inputInvoice: InvoiceSchema,
+	ownerId: string
+) => {
+	const groupActivitiesToCreate = inputInvoice.activitiesToCreate.filter(
+		(activity) => activity.groupClientIds.length > 0
+	);
+
+	if (groupActivitiesToCreate.length === 0) return;
+
+	for (const activity of groupActivitiesToCreate) {
+		if (
+			new Set(activity.groupClientIds).size !== activity.groupClientIds.length
+		) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "Group participants must be distinct"
+			});
+		}
+
+		if (activity.groupClientIds.includes(inputInvoice.clientId)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "The primary client cannot also be a group participant"
+			});
+		}
+	}
+
+	const allGroupClientIds = groupActivitiesToCreate.flatMap(
+		(activity) => activity.groupClientIds
+	);
+
+	const clients = await ctx.owned.client.findMany({
+		where: { id: { in: allGroupClientIds } }
+	});
+
+	if (clients.length !== new Set(allGroupClientIds).size) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "One or more group clients not found"
+		});
+	}
+
+	await ctx.prisma.activity.createMany(
+		generateNestedWriteForGroupActivities(
+			groupActivitiesToCreate,
+			ownerId,
+			clients
+		)
+	);
+};
 
 export const invoiceRouter = router({
 	list: authedProcedure
@@ -240,28 +344,10 @@ export const invoiceRouter = router({
 				);
 			}
 
-			const soloRowSupportItemIds = [
-				...new Set(
-					inputInvoice.activitiesToCreate
-						.filter((activity) => activity.groupClientIds.length === 0)
-						.map((activity) => activity.supportItemId)
-				)
-			];
-
-			if (soloRowSupportItemIds.length > 0) {
-				const groupSupportItemsAmongSoloRows =
-					await ctx.owned.supportItem.findMany({
-						where: { id: { in: soloRowSupportItemIds }, isGroup: true },
-						select: { id: true }
-					});
-
-				if (groupSupportItemsAmongSoloRows.length > 0) {
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message: "Group activities require at least one other participant"
-					});
-				}
-			}
+			await assertGroupRowsHaveParticipants(
+				ctx.owned,
+				inputInvoice.activitiesToCreate
+			);
 
 			const invoice = await ctx.prisma.invoice.create({
 				data: {
@@ -285,57 +371,7 @@ export const invoiceRouter = router({
 				throw new TRPCError({ code: "NOT_FOUND" });
 			}
 
-			const groupActivitiesToCreate = inputInvoice.activitiesToCreate.filter(
-				(activity) => activity.groupClientIds.length > 0
-			);
-
-			if (groupActivitiesToCreate.length > 0) {
-				for (const activity of groupActivitiesToCreate) {
-					if (
-						new Set(activity.groupClientIds).size !==
-						activity.groupClientIds.length
-					) {
-						throw new TRPCError({
-							code: "BAD_REQUEST",
-							message: "Group participants must be distinct"
-						});
-					}
-
-					if (activity.groupClientIds.includes(inputInvoice.clientId)) {
-						throw new TRPCError({
-							code: "BAD_REQUEST",
-							message: "The primary client cannot also be a group participant"
-						});
-					}
-				}
-
-				const allGroupClientIds = groupActivitiesToCreate.flatMap(
-					(activity) => activity.groupClientIds
-				);
-
-				const clients = await ctx.owned.client.findMany({
-					where: {
-						id: {
-							in: allGroupClientIds
-						}
-					}
-				});
-
-				if (clients.length !== new Set(allGroupClientIds).size) {
-					throw new TRPCError({
-						code: "NOT_FOUND",
-						message: "One or more group clients not found"
-					});
-				}
-
-				await ctx.prisma.activity.createMany(
-					generateNestedWriteForGroupActivities(
-						groupActivitiesToCreate,
-						ctx.session.user.id,
-						clients
-					)
-				);
-			}
+			await createGroupMirrorActivities(ctx, inputInvoice, ctx.session.user.id);
 
 			return parseInvoice(invoice);
 		}),
@@ -360,6 +396,13 @@ export const invoiceRouter = router({
 				await ctx.owned.activity.assertAll(
 					inputInvoice.activityIds,
 					"One or more activities not found"
+				);
+			}
+
+			if (client) {
+				await assertGroupRowsHaveParticipants(
+					ctx.owned,
+					inputInvoice.activitiesToCreate
 				);
 			}
 
@@ -394,6 +437,14 @@ export const invoiceRouter = router({
 
 			if (!invoice) {
 				throw new TRPCError({ code: "NOT_FOUND" });
+			}
+
+			if (client) {
+				await createGroupMirrorActivities(
+					ctx,
+					inputInvoice,
+					ctx.session.user.id
+				);
 			}
 
 			return {

--- a/src/server/api/test/invoice-group-creation.integration.test.ts
+++ b/src/server/api/test/invoice-group-creation.integration.test.ts
@@ -1,0 +1,204 @@
+import prisma from "@/server/prisma";
+import type { User } from "@/generated/client";
+import { beforeEach, describe, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "./harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function createGroupSupportItem(owner: User) {
+	return prisma.supportItem.create({
+		data: {
+			description: "Group Activities - Standard",
+			isGroup: true,
+			weekdayCode: "04_102_0136_6_1",
+			weekdayRate: 70.2,
+			ownerId: owner.id
+		}
+	});
+}
+
+async function createClients(owner: User, count: number) {
+	return Promise.all(
+		Array.from({ length: count }, (_, index) =>
+			prisma.client.create({
+				data: { name: `Client ${index + 1}`, ownerId: owner.id }
+			})
+		)
+	);
+}
+
+function activityToCreate({
+	supportItemId,
+	groupClientIds
+}: {
+	supportItemId: string;
+	groupClientIds: string[];
+}) {
+	return {
+		supportItemId,
+		groupClientIds,
+		activities: [
+			{
+				date: new Date("2024-01-01"),
+				startTime: "09:00",
+				endTime: "11:00"
+			}
+		]
+	};
+}
+
+describe("invoice.create with group activities", () => {
+	test("fans out one mirrored activity per group client and stamps groupSize on all of them", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, ...others] = await createClients(owner, 3);
+
+		const invoice = await caller.invoice.create({
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					activityToCreate({
+						supportItemId: supportItem.id,
+						groupClientIds: others.map((c) => c.id)
+					})
+				]
+			}
+		});
+
+		const activities = await prisma.activity.findMany({
+			where: { invoiceId: invoice.id },
+			select: { clientId: true, groupSize: true }
+		});
+		const pending = await prisma.activity.findMany({
+			where: { ownerId: owner.id, invoiceId: null },
+			select: { clientId: true, groupSize: true }
+		});
+
+		expect(activities).toHaveLength(1);
+		expect(activities[0]).toEqual({ clientId: primary.id, groupSize: 3 });
+		expect(pending).toHaveLength(2);
+		expect(new Set(pending.map((a) => a.clientId))).toEqual(
+			new Set(others.map((c) => c.id))
+		);
+		expect(pending.every((a) => a.groupSize === 3)).toBe(true);
+	});
+
+	test("succeeds with 9 group clients (10 activities total)", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, ...others] = await createClients(owner, 10);
+
+		await caller.invoice.create({
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					activityToCreate({
+						supportItemId: supportItem.id,
+						groupClientIds: others.map((c) => c.id)
+					})
+				]
+			}
+		});
+
+		const activities = await prisma.activity.findMany({
+			where: { ownerId: owner.id },
+			select: { groupSize: true }
+		});
+		expect(activities).toHaveLength(10);
+		expect(activities.every((a) => a.groupSize === 10)).toBe(true);
+	});
+
+	test("rejects 10 group clients (11 participants, over the cap)", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, ...others] = await createClients(owner, 11);
+
+		await expect(
+			caller.invoice.create({
+				invoice: {
+					clientId: primary.id,
+					invoiceNo: "INV-1",
+					activitiesToCreate: [
+						activityToCreate({
+							supportItemId: supportItem.id,
+							groupClientIds: others.map((c) => c.id)
+						})
+					]
+				}
+			})
+		).rejects.toThrow();
+	});
+
+	test("rejects duplicate group client ids", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, other] = await createClients(owner, 2);
+
+		await expect(
+			caller.invoice.create({
+				invoice: {
+					clientId: primary.id,
+					invoiceNo: "INV-1",
+					activitiesToCreate: [
+						activityToCreate({
+							supportItemId: supportItem.id,
+							groupClientIds: [other.id, other.id]
+						})
+					]
+				}
+			})
+		).rejects.toThrow(/distinct/i);
+	});
+
+	test("rejects the primary client appearing among the group clients", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, other] = await createClients(owner, 2);
+
+		await expect(
+			caller.invoice.create({
+				invoice: {
+					clientId: primary.id,
+					invoiceNo: "INV-1",
+					activitiesToCreate: [
+						activityToCreate({
+							supportItemId: supportItem.id,
+							groupClientIds: [other.id, primary.id]
+						})
+					]
+				}
+			})
+		).rejects.toThrow(/primary client/i);
+	});
+
+	test("rejects a group support item with zero group clients", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary] = await createClients(owner, 1);
+
+		await expect(
+			caller.invoice.create({
+				invoice: {
+					clientId: primary.id,
+					invoiceNo: "INV-1",
+					activitiesToCreate: [
+						activityToCreate({
+							supportItemId: supportItem.id,
+							groupClientIds: []
+						})
+					]
+				}
+			})
+		).rejects.toThrow(/at least one other participant/i);
+	});
+});

--- a/src/server/api/test/invoice-group-creation.integration.test.ts
+++ b/src/server/api/test/invoice-group-creation.integration.test.ts
@@ -202,3 +202,81 @@ describe("invoice.create with group activities", () => {
 		).rejects.toThrow(/at least one other participant/i);
 	});
 });
+
+describe("invoice.modify with group activities", () => {
+	test("fans out mirrored activities and stamps groupSize when a group row is added on edit", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, ...others] = await createClients(owner, 3);
+
+		const invoice = await caller.invoice.create({
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: []
+			}
+		});
+
+		await caller.invoice.modify({
+			id: invoice.id,
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					activityToCreate({
+						supportItemId: supportItem.id,
+						groupClientIds: others.map((c) => c.id)
+					})
+				]
+			}
+		});
+
+		const onInvoice = await prisma.activity.findMany({
+			where: { invoiceId: invoice.id },
+			select: { clientId: true, groupSize: true }
+		});
+		const pending = await prisma.activity.findMany({
+			where: { ownerId: owner.id, invoiceId: null },
+			select: { clientId: true, groupSize: true }
+		});
+
+		expect(onInvoice).toEqual([{ clientId: primary.id, groupSize: 3 }]);
+		expect(pending).toHaveLength(2);
+		expect(new Set(pending.map((a) => a.clientId))).toEqual(
+			new Set(others.map((c) => c.id))
+		);
+		expect(pending.every((a) => a.groupSize === 3)).toBe(true);
+	});
+
+	test("rejects the primary client appearing among the group clients on edit", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createGroupSupportItem(owner);
+		const [primary, other] = await createClients(owner, 2);
+
+		const invoice = await caller.invoice.create({
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: []
+			}
+		});
+
+		await expect(
+			caller.invoice.modify({
+				id: invoice.id,
+				invoice: {
+					clientId: primary.id,
+					invoiceNo: "INV-1",
+					activitiesToCreate: [
+						activityToCreate({
+							supportItemId: supportItem.id,
+							groupClientIds: [other.id, primary.id]
+						})
+					]
+				}
+			})
+		).rejects.toThrow(/primary client/i);
+	});
+});


### PR DESCRIPTION
## Summary
- Group activities now record a participant count (`Activity.groupSize`, 2–10) instead of being hardwired to exactly 2; every participant gets a mirrored activity via `groupClientIds` (replaces the old single `groupClientId`).
- Hourly support rates, Provider Travel per-km, and Activity Based Transport per-km all apportion by group size — `floorToCent(rate ÷ N)` — computed once in `billing-lines.ts`'s `billableLines`, so a group support item's stored rate is now the full-session amount rather than a per-participant one.
- Migration backfills existing group activities to `groupSize = 2` and doubles existing group `SupportItem`/`SupportItemRates` rates so N=2 billing is unchanged (except a deliberate −1c/km transit fix: 0.85÷2 = $0.42, replacing the old hardcoded $0.43).
- Both activity-creation flows (quick-entry and invoice creation) accept 1–9 extra participants with add/remove UI, excluding the primary and already-chosen clients.
- Fixed during review: a group support item submitted with zero participants used to silently default to N=2 (a real billing bug) — now rejected server-side; duplicate-participant selection is now blocked in both forms.

See `docs/plans/complete/016-group-activities-up-to-10-participants.md` for the full plan, operator decisions, and rate-math details.

## Code-review follow-ups
- **Apportioning in one place** — the `isGroup` gate + `floorToCent(rate ÷ N)` floor policy now lives in a single `apportion()` helper in `billing-lines.ts`, called by the hourly, transit, and ABT sites.
- **Single-sourced group-size math** — `totalGroupSize()` in `invoice-schema.ts` replaces the repeated `groupClientIds.length + 1`; the participant list add/update/remove/cap logic is shared by both forms via `src/lib/group-participants.ts`.
- **Clearer constant** — `MAX_GROUP_PARTICIPANTS` renamed to `MAX_ADDITIONAL_GROUP_PARTICIPANTS` (it caps the *other* participants; 10 total).
- **`modify` now handles groups** — the invoice edit flow renders the same participant UI, so `invoice.modify` reused the shared validation + mirror fan-out helpers. Previously editing in a group row would stamp `groupSize` on the primary with no sibling activities.
- Corrected a stale total in the `plan-managed-week` fixture comment ($1160.74 → the actual golden $1153.46).

## Test plan
- [x] `pnpm exec vitest run` — 78 unit tests pass, including `floorToCent` pins, N=2/3/10 apportioning cases, and the N=3 golden-master fixture
- [x] `pnpm exec vitest run --config vitest.integration.config.mts` — 18 integration tests pass, including group creation (fan-out, 9-participant cap, duplicate/primary-id rejection, zero-participant rejection) and new coverage for the group fan-out through `invoice.modify`
- [x] `pnpm exec playwright test --project=e2e` — 17 e2e tests pass
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check` all exit 0
- [x] Golden-master diffs confined to the documented `$0.43→$0.42` transit lines/totals in `transit-group` and `plan-managed-week`; every other fixture byte-identical
