### PR TITLE
Invoice versioning: freeze sent invoices into immutable versions (plan 017)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ See `manage-plans` skill for lifecycle conventions. TRDs in [`docs/trd/`](../trd
 
 | Plan | Title                                                          | Priority | Effort | Depends on | Status |
 | ---- | -------------------------------------------------------------- | -------- | ------ | ---------- | ------ |
-| 017  | Invoice versioning — sent invoices freeze an immutable version | P1       | L      | 007        | TODO   |
+| 017  | Invoice versioning — sent invoices freeze an immutable version | P1       | L      | 007        | DONE   |
 
 Status: `TODO` | `IN PROGRESS` | `DONE` | `BLOCKED (reason)` | `REJECTED (rationale)`
 

--- a/e2e/invoice-versioning.test.ts
+++ b/e2e/invoice-versioning.test.ts
@@ -1,0 +1,166 @@
+import { extractPdfText } from "@/lib/testing/pdf-test-utils";
+import { expect, test } from "@playwright/test";
+import { randomInvoice } from "./random/random-invoice";
+import {
+	createRandomActivity,
+	createRandomClient,
+	createRandomSupportItem,
+	waitForAlert
+} from "./test-utils";
+
+/**
+ * The Step 7 journey from docs/plans/017-invoice-versioning.md: create →
+ * download draft (watermarked) → send & download (clean v1) → amend
+ * (confirm) → edit an activity → send → v2 with the supersedes line; both
+ * versions stay downloadable; the list shows one row for the one invoice.
+ */
+test("Invoice versioning journey: draft → send → amend → edit → re-send freezes v2", async ({
+	page
+}) => {
+	const client = await createRandomClient();
+	const supportItem = await createRandomSupportItem();
+	await createRandomActivity(client.id, supportItem.id, {
+		startTime: "09:00",
+		endTime: "10:00"
+	});
+
+	const invoice = randomInvoice();
+
+	await page.goto("/dashboard/invoices");
+	await page.getByRole("link", { name: "Add" }).click();
+	await page.getByLabel("Client").click();
+	await page.getByLabel(client.name).first().click();
+
+	const invoiceNoInput = page.getByLabel("Invoice Number");
+	await expect(invoiceNoInput).toHaveValue(
+		client.invoiceNumberPrefix ? `${client.invoiceNumberPrefix}1` : ""
+	);
+	await invoiceNoInput.fill(invoice.invoiceNo);
+	await page
+		.getByText(supportItem.description, { exact: true })
+		.first()
+		.click();
+	await page.getByRole("button", { name: "Create" }).click();
+	await waitForAlert(page, "invoice created");
+
+	await page
+		.getByRole("row")
+		.filter({ hasText: invoice.invoiceNo })
+		.getByRole("link", { name: invoice.invoiceNo })
+		.click();
+	await expect(page).toHaveURL(/\/dashboard\/invoices\/[^/]+$/);
+	const invoiceId = page.url().split("/").pop()!;
+
+	// --- Download draft: DRAFT-watermarked, no supersedes line ---
+	await page.getByRole("button", { name: "Download" }).click();
+	await page.getByRole("menuitem", { name: "Download draft" }).click();
+
+	const draftResponse = await page.request.get(
+		`/api/invoices/generate-pdf/${invoiceId}?base64=true`
+	);
+	expect(draftResponse.status()).toBe(200);
+	const draftText = await extractPdfText(await draftResponse.text());
+	expect(draftText).toContain("DRAFT");
+	expect(draftText).toContain(`Invoice Number: ${invoice.invoiceNo}`);
+	expect(draftText).not.toContain("supersedes");
+
+	// --- Send & download: freezes v1, clean render, locks the invoice ---
+	await page.getByRole("button", { name: "Download" }).click();
+	await page.getByRole("menuitem", { name: "Send & download" }).click();
+
+	await expect(page.getByRole("button", { name: "Amend" })).toBeVisible({
+		timeout: 10000
+	});
+	await expect(
+		page.getByRole("heading", { name: invoice.invoiceNo, exact: true })
+	).toBeVisible();
+
+	const v1Response = await page.request.get(
+		`/api/invoices/generate-pdf/${invoiceId}?base64=true`
+	);
+	expect(v1Response.status()).toBe(200);
+	expect(v1Response.headers()["content-disposition"]).toContain(
+		`${invoice.invoiceNo}.pdf`
+	);
+	const v1Text = await extractPdfText(await v1Response.text());
+	expect(v1Text).not.toContain("DRAFT");
+	expect(v1Text).not.toContain("supersedes");
+
+	// --- Amend: confirm dialog, unlocks back to draft ---
+	page.once("dialog", (dialog) => {
+		dialog.accept().catch(() => {});
+	});
+	await page.getByRole("button", { name: "Amend" }).click();
+	await expect(page.getByRole("button", { name: "Mark as Sent" })).toBeVisible({
+		timeout: 10000
+	});
+
+	// --- Edit the activity that's on the invoice ---
+	await page.goto("/dashboard/activities");
+	await page
+		.getByRole("link")
+		.filter({ hasText: supportItem.description })
+		.click();
+	await page
+		.locator("div")
+		.filter({ hasText: new RegExp(`^${supportItem.description}$`) })
+		.getByRole("button")
+		.click();
+	await page.getByRole("menuitem", { name: "Edit" }).click();
+	await page.getByLabel("Start Time").fill("09:30");
+	await page.getByLabel("End Time").fill("11:00");
+	await page.getByRole("button", { name: "Update" }).click();
+	await waitForAlert(page, "activity updated");
+
+	// --- Re-send: freezes v2 with the supersedes line ---
+	await page.goto(`/dashboard/invoices/${invoiceId}`);
+	await page.getByRole("button", { name: "Mark as Sent" }).click();
+	await expect(page.getByRole("button", { name: "Amend" })).toBeVisible({
+		timeout: 10000
+	});
+	await expect(
+		page.getByRole("heading", { name: `${invoice.invoiceNo}a`, exact: true })
+	).toBeVisible();
+
+	const v2Response = await page.request.get(
+		`/api/invoices/generate-pdf/${invoiceId}?base64=true`
+	);
+	expect(v2Response.headers()["content-disposition"]).toContain(
+		`${invoice.invoiceNo}a.pdf`
+	);
+	const v2Text = await extractPdfText(await v2Response.text());
+	expect(v2Text).toContain(`Invoice Number: ${invoice.invoiceNo}a`);
+	expect(v2Text).toContain(
+		`This invoice amends and supersedes ${invoice.invoiceNo}`
+	);
+
+	// --- Both versions stay downloadable, by explicit version number ---
+	const v1Again = await page.request.get(
+		`/api/invoices/generate-pdf/${invoiceId}?base64=true&versionNumber=1`
+	);
+	expect(v1Again.status()).toBe(200);
+	expect(v1Again.headers()["content-disposition"]).toContain(
+		`${invoice.invoiceNo}.pdf`
+	);
+	const v2Again = await page.request.get(
+		`/api/invoices/generate-pdf/${invoiceId}?base64=true&versionNumber=2`
+	);
+	expect(v2Again.status()).toBe(200);
+	expect(v2Again.headers()["content-disposition"]).toContain(
+		`${invoice.invoiceNo}a.pdf`
+	);
+
+	// --- Version history lists both versions on the invoice page ---
+	await expect(
+		page.getByText(invoice.invoiceNo, { exact: true }).first()
+	).toBeVisible();
+	await expect(
+		page.getByText(`${invoice.invoiceNo}a`, { exact: true }).first()
+	).toBeVisible();
+
+	// --- The list shows one row for this invoice, not one per version ---
+	await page.goto("/dashboard/invoices");
+	await expect(
+		page.getByRole("row").filter({ hasText: invoice.invoiceNo })
+	).toHaveCount(1);
+});

--- a/e2e/setup/global.setup.ts
+++ b/e2e/setup/global.setup.ts
@@ -4,11 +4,30 @@ import { FullConfig, chromium } from "@playwright/test";
 import { addMonths, getUnixTime } from "date-fns";
 import { testUser } from "../test-utils";
 
+/**
+ * `InvoiceVersion.invoiceId` is `onDelete: Restrict` (docs/adr/0004) — a
+ * user with any sent invoice can't cascade-delete, so wipe versions first.
+ */
+async function deleteTestUserAndData(email: string) {
+	const invoices = await prisma.invoice.findMany({
+		where: { owner: { email } },
+		select: { id: true }
+	});
+
+	if (invoices.length > 0) {
+		await prisma.invoiceVersion.deleteMany({
+			where: { invoiceId: { in: invoices.map((invoice) => invoice.id) } }
+		});
+	}
+
+	await prisma.user.deleteMany({ where: { email } });
+}
+
 async function globalSetup(config: FullConfig) {
 	const { baseURL, storageState } = config.projects[0].use;
 
-	await prisma.user.deleteMany({ where: { email: testUser.email } });
-	const user = await prisma.user.create({
+	await deleteTestUserAndData(testUser.email);
+	await prisma.user.create({
 		data: testUser
 	});
 
@@ -33,7 +52,7 @@ async function globalSetup(config: FullConfig) {
 	await browser.close();
 
 	const globalTeardown = async () => {
-		await prisma.user.delete({ where: { id: user.id } });
+		await deleteTestUserAndData(testUser.email);
 	};
 
 	return globalTeardown;

--- a/prisma/migrations/20260707112650_invoice_versioning/migration.sql
+++ b/prisma/migrations/20260707112650_invoice_versioning/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "Client" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "InvoiceVersion" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "invoiceId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL,
+    "paidAt" TIMESTAMP(3),
+    "total" DECIMAL(65,30) NOT NULL,
+    "content" JSONB NOT NULL,
+
+    CONSTRAINT "InvoiceVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InvoiceVersion_invoiceId_idx" ON "InvoiceVersion"("invoiceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InvoiceVersion_invoiceId_versionNumber_key" ON "InvoiceVersion"("invoiceId", "versionNumber");
+
+-- AddForeignKey
+ALTER TABLE "InvoiceVersion" ADD CONSTRAINT "InvoiceVersion_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
+  provider     = "prisma-client"
+  output       = "../generated/prisma"
   moduleFormat = "cjs"
 }
 
@@ -86,10 +86,11 @@ model Client {
   name         String
   number       String?
   invoiceEmail String?
+  active       Boolean @default(true)
 
-  distanceToClient      Decimal? @map("defaultTransitDistance")
-  travelTimeToClient    Decimal? @map("defaultTransitTime")
-  transitRatePerKm Decimal?
+  distanceToClient   Decimal? @map("defaultTransitDistance")
+  travelTimeToClient Decimal? @map("defaultTransitTime")
+  transitRatePerKm   Decimal?
 
   billTo              String?
   invoiceNumberPrefix String?
@@ -103,23 +104,39 @@ model Client {
 }
 
 model Invoice {
-  id         String        @id @default(cuid())
-  createdAt  DateTime      @default(now()) @map("created")
-  updatedAt  DateTime      @default(now()) @updatedAt
+  id         String           @id @default(cuid())
+  createdAt  DateTime         @default(now()) @map("created")
+  updatedAt  DateTime         @default(now()) @updatedAt
   sentAt     DateTime?
   paidAt     DateTime?
   invoiceNo  String
   billTo     String?
   date       DateTime
-  status     InvoiceStatus @default(CREATED)
+  status     InvoiceStatus    @default(CREATED)
   clientId   String
   ownerId    String
   activities Activity[]
-  client     Client        @relation(fields: [clientId], references: [id], onDelete: Cascade)
-  owner      User          @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  client     Client           @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  owner      User             @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  versions   InvoiceVersion[]
 
   @@index([clientId])
   @@index([ownerId])
+}
+
+model InvoiceVersion {
+  id            String    @id @default(cuid())
+  createdAt     DateTime  @default(now())
+  invoiceId     String
+  invoice       Invoice   @relation(fields: [invoiceId], references: [id], onDelete: Restrict)
+  versionNumber Int // 1-based; display suffix derived from this
+  sentAt        DateTime // freeze moment
+  paidAt        DateTime? // stamped by markPaid; survives amendment
+  total         Decimal // denormalized for lists/owing queries
+  content       Json // full frozen document, Zod-validated
+
+  @@unique([invoiceId, versionNumber])
+  @@index([invoiceId])
 }
 
 model Activity {
@@ -144,7 +161,7 @@ model Activity {
   invoice         Invoice?    @relation(fields: [invoiceId], references: [id], onDelete: SetNull)
   trip            Trip?       @relation(fields: [tripId], references: [id], onDelete: SetNull)
 
-  transportItems  ActivityTransportItem[]
+  transportItems ActivityTransportItem[]
 
   @@index([ownerId])
   @@index([ownerId, date, startTime])

--- a/prisma/scripts/backfill-invoice-versions.integration.test.ts
+++ b/prisma/scripts/backfill-invoice-versions.integration.test.ts
@@ -1,0 +1,193 @@
+import prisma from "@/server/prisma";
+import { getTotalCostOfActivities } from "@/lib/activity-utils";
+import { beforeEach, expect, test } from "vitest";
+import {
+	callerFor,
+	createTestUser,
+	resetDb
+} from "../../src/server/api/test/harness";
+import { backfillInvoiceVersions } from "./backfill-invoice-versions";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function createLegacySentInvoice(
+	user: Awaited<ReturnType<typeof createTestUser>>,
+	options: { paid?: boolean } = {}
+) {
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Legacy Client" }
+	});
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "11:00",
+			itemDistance: 0
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-LEGACY",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	// Simulate a pre-plan-017 SENT/PAID invoice: status set directly, no
+	// InvoiceVersion row — this is exactly what `send` could never produce
+	// after this plan, but is the real shape of historic data.
+	const sentAt = new Date("2024-01-05");
+	await prisma.invoice.update({
+		where: { id: invoice.id },
+		data: {
+			status: options.paid ? "PAID" : "SENT",
+			sentAt,
+			paidAt: options.paid ? new Date("2024-01-10") : null
+		}
+	});
+
+	const expectedTotal = getTotalCostOfActivities(
+		[
+			{
+				...activity,
+				supportItem: { ...supportItem, rateType: "HOUR" }
+			}
+		],
+		{ userTransitRatePerKm: 0.99 }
+	);
+
+	return { caller, client, supportItem, activity, invoice, expectedTotal };
+}
+
+test("backfills a v1 flagged `backfilled` for a legacy SENT invoice, matching the live total at backfill time", async () => {
+	const user = await createTestUser();
+	const { invoice, expectedTotal } = await createLegacySentInvoice(user);
+
+	const result = await backfillInvoiceVersions();
+	expect(result.backfilled).toBe(1);
+	expect(result.skipped).toBe(0);
+
+	const versions = await prisma.invoiceVersion.findMany({
+		where: { invoiceId: invoice.id }
+	});
+	expect(versions).toHaveLength(1);
+	expect(versions[0].versionNumber).toBe(1);
+	expect(Number(versions[0].total)).toBeCloseTo(expectedTotal, 2);
+
+	const content = versions[0].content as { backfilled?: boolean };
+	expect(content.backfilled).toBe(true);
+
+	const caller = callerFor(user);
+	const owing = await caller.invoice.getTotalOwing();
+	expect(owing).toBeCloseTo(expectedTotal, 2);
+});
+
+test("stamps paidAt onto the backfilled version for a legacy PAID invoice", async () => {
+	const user = await createTestUser();
+	const { invoice } = await createLegacySentInvoice(user, { paid: true });
+
+	await backfillInvoiceVersions();
+
+	const version = await prisma.invoiceVersion.findFirstOrThrow({
+		where: { invoiceId: invoice.id }
+	});
+	expect(version.paidAt).not.toBeNull();
+});
+
+test("is idempotent — a second run touches nothing", async () => {
+	const user = await createTestUser();
+	await createLegacySentInvoice(user);
+
+	await backfillInvoiceVersions();
+	const secondRun = await backfillInvoiceVersions();
+
+	expect(secondRun.backfilled).toBe(0);
+	expect(secondRun.skipped).toBe(0);
+
+	const allVersions = await prisma.invoiceVersion.findMany();
+	expect(allVersions).toHaveLength(1);
+});
+
+test("does not touch a draft (CREATED) invoice or one that already has a version", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Draft" } });
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const draftInvoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-DRAFT",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	const alreadyVersionedInvoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-SENT",
+			activitiesToCreate: []
+		}
+	});
+	await prisma.activity.create({
+		data: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			ownerId: user.id,
+			invoiceId: alreadyVersionedInvoice.id,
+			date: new Date("2024-01-02"),
+			startTime: new Date("1970-01-01T09:00:00.000Z"),
+			endTime: new Date("1970-01-01T10:00:00.000Z"),
+			itemDistance: 0
+		}
+	});
+	await caller.invoice.send({ ids: [alreadyVersionedInvoice.id] });
+
+	const result = await backfillInvoiceVersions();
+
+	expect(result.backfilled).toBe(0);
+	expect(result.skipped).toBe(0);
+
+	const draftVersions = await prisma.invoiceVersion.findMany({
+		where: { invoiceId: draftInvoice.id }
+	});
+	expect(draftVersions).toHaveLength(0);
+
+	const existingVersions = await prisma.invoiceVersion.findMany({
+		where: { invoiceId: alreadyVersionedInvoice.id }
+	});
+	expect(existingVersions).toHaveLength(1);
+});

--- a/prisma/scripts/backfill-invoice-versions.ts
+++ b/prisma/scripts/backfill-invoice-versions.ts
@@ -1,0 +1,94 @@
+/**
+ * One-off backfill (docs/plans/017 Step 9): every SENT/PAID invoice sent
+ * before this feature existed has no `InvoiceVersion` row. This builds a v1
+ * from *current* live data for each of them, flagged `backfilled: true`.
+ *
+ * Idempotent — only touches invoices with zero versions, so re-running is a
+ * no-op. Must run once, after the schema migration, before the
+ * frozen-total money queries (docs/plans/017 Step 8) see production traffic:
+ * those queries read `versions[0].total`, which is `0` for a SENT/PAID
+ * invoice with no version yet.
+ *
+ * Run with: pnpm exec tsx prisma/scripts/backfill-invoice-versions.ts
+ */
+import "dotenv/config";
+import prisma from "@/server/prisma";
+import { InvoiceStatus } from "@/generated/client";
+import { loadInvoiceForPdf } from "@/lib/pdf-generation";
+import { buildInvoiceVersionContent } from "@/lib/invoice-version";
+
+export interface BackfillResult {
+	backfilled: number;
+	skipped: number;
+}
+
+export async function backfillInvoiceVersions(): Promise<BackfillResult> {
+	const invoices = await prisma.invoice.findMany({
+		where: {
+			status: { in: [InvoiceStatus.SENT, InvoiceStatus.PAID] },
+			versions: { none: {} }
+		},
+		select: {
+			id: true,
+			ownerId: true,
+			invoiceNo: true,
+			sentAt: true,
+			paidAt: true,
+			date: true
+		}
+	});
+
+	console.log(`Found ${invoices.length} SENT/PAID invoice(s) with no version.`);
+
+	let backfilled = 0;
+	let skipped = 0;
+
+	for (const invoice of invoices) {
+		const data = await loadInvoiceForPdf(invoice.id, invoice.ownerId);
+
+		if (!data) {
+			console.warn(
+				`Skipping ${invoice.invoiceNo} (${invoice.id}) — could not load for PDF (missing client or activities).`
+			);
+			skipped += 1;
+			continue;
+		}
+
+		const content = buildInvoiceVersionContent(data, {
+			versionNumber: 1,
+			backfilled: true
+		});
+
+		await prisma.invoiceVersion.create({
+			data: {
+				invoiceId: invoice.id,
+				versionNumber: 1,
+				sentAt: invoice.sentAt ?? invoice.date,
+				paidAt: invoice.paidAt,
+				total: content.total,
+				content
+			}
+		});
+
+		backfilled += 1;
+		console.log(`Backfilled v1 for ${invoice.invoiceNo} (${invoice.id}).`);
+	}
+
+	console.log(`Done. Backfilled ${backfilled}, skipped ${skipped}.`);
+
+	return { backfilled, skipped };
+}
+
+// Only auto-run when executed directly (`pnpm exec tsx
+// prisma/scripts/backfill-invoice-versions.ts`) — not when imported by
+// the integration test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	backfillInvoiceVersions()
+		.catch((error) => {
+			console.error(error);
+			process.exitCode = 1;
+		})
+		.finally(async () => {
+			await prisma.$disconnect();
+		});
+}

--- a/src/components/clients/client-list.tsx
+++ b/src/components/clients/client-list.tsx
@@ -1,6 +1,8 @@
 import { DeleteEntityButton } from "@/components/shared/delete-entity-button";
 import ListPage from "@/components/shared/list-page";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import DataTable, { SortingHeader } from "@/components/ui/data-table";
 import {
 	DropdownMenu,
@@ -13,14 +15,19 @@ import { ClientListOutput } from "@/server/api/routers/client-router";
 import { ColumnDef } from "@tanstack/react-table";
 import { MoreHorizontal, Pencil } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
 
 const columns: ColumnDef<ClientListOutput>[] = [
 	{
 		accessorKey: "name",
 		header: ({ column }) => <SortingHeader column={column}>Name</SortingHeader>,
 		cell: ({ row }) => (
-			<Link href={`/dashboard/clients/${row.original.id}`}>
+			<Link
+				href={`/dashboard/clients/${row.original.id}`}
+				className="flex items-center gap-2"
+			>
 				{row.getValue("name")}
+				{!row.original.active && <Badge variant="secondary">Inactive</Badge>}
 			</Link>
 		)
 	},
@@ -73,13 +80,25 @@ const columns: ColumnDef<ClientListOutput>[] = [
 ];
 
 const ClientList = () => {
-	const { data: clients } = trpc.clients.list.useQuery({});
+	const [includeInactive, setIncludeInactive] = useState(false);
+	const { data: clients } = trpc.clients.list.useQuery({ includeInactive });
 
 	return (
 		<ListPage>
 			<ListPage.Header
 				title="Clients"
 				createNewHref="/dashboard/clients/create"
+				extraButtons={
+					<label className="flex items-center gap-2 text-sm whitespace-nowrap">
+						<Checkbox
+							checked={includeInactive}
+							onCheckedChange={(checked) =>
+								setIncludeInactive(checked === true)
+							}
+						/>
+						Show inactive
+					</label>
+				}
 			/>
 
 			{clients && <DataTable columns={columns} data={clients.clients} />}

--- a/src/components/clients/client-page.tsx
+++ b/src/components/clients/client-page.tsx
@@ -1,6 +1,7 @@
 import CustomRatesTable from "@/components/clients/custom-rates-table";
 import SupportItemOverrideDialog from "@/components/clients/support-item-override-dialog";
 import InvoiceList from "@/components/invoices/invoice-list";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -11,7 +12,14 @@ import {
 import Heading from "@/components/ui/heading";
 import Loading from "@/components/ui/loading";
 import { trpc } from "@/lib/trpc";
-import { EllipsisVertical, ExternalLink, Pencil, Trash } from "lucide-react";
+import {
+	Archive,
+	ArchiveRestore,
+	EllipsisVertical,
+	ExternalLink,
+	Pencil,
+	Trash
+} from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
@@ -25,6 +33,7 @@ const ClientPage = ({ clientId }: { clientId: string }) => {
 	});
 
 	const deleteClientMutation = trpc.clients.delete.useMutation();
+	const updateClientMutation = trpc.clients.update.useMutation();
 
 	const deleteClient = () => {
 		if (confirm("Are you sure?"))
@@ -35,9 +44,40 @@ const ClientPage = ({ clientId }: { clientId: string }) => {
 					toast.success("Client deleted");
 					router.push("/dashboard/clients");
 				})
-				.catch(() => {
-					toast.error("An error occured. Please refresh and try again.");
+				.catch((error) => {
+					toast.error(
+						error instanceof Error
+							? error.message
+							: "An error occured. Please refresh and try again."
+					);
 				});
+	};
+
+	const toggleActive = () => {
+		if (!client) return;
+
+		updateClientMutation
+			.mutateAsync({
+				id: client.id,
+				client: {
+					name: client.name,
+					number: client.number ?? undefined,
+					billTo: client.billTo ?? undefined,
+					invoiceNumberPrefix: client.invoiceNumberPrefix ?? undefined,
+					distanceToClient: client.distanceToClient?.toString(),
+					travelTimeToClient: client.travelTimeToClient?.toString(),
+					transitRatePerKm: client.transitRatePerKm?.toString(),
+					invoiceEmail: client.invoiceEmail ?? undefined,
+					active: !client.active
+				}
+			})
+			.then(() => {
+				trpcUtils.clients.byId.invalidate({ id: clientId });
+				trpcUtils.clients.list.invalidate();
+				toast.success(
+					client.active ? "Client deactivated" : "Client reactivated"
+				);
+			});
 	};
 
 	if (error) {
@@ -50,7 +90,10 @@ const ClientPage = ({ clientId }: { clientId: string }) => {
 		<div className="mx-auto flex w-full max-w-4xl flex-col items-start justify-center p-4">
 			<div className="my-2 flex w-full flex-col gap-2 px-4 sm:my-8">
 				<div className="mb-2 flex items-center justify-between">
-					<Heading>{client.name}</Heading>
+					<div className="flex items-center gap-2">
+						<Heading>{client.name}</Heading>
+						{!client.active && <Badge variant="secondary">Inactive</Badge>}
+					</div>
 
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild className="grow-0">
@@ -65,6 +108,23 @@ const ClientPage = ({ clientId }: { clientId: string }) => {
 									<span>Edit</span>
 								</DropdownMenuItem>
 							</Link>
+
+							<DropdownMenuItem
+								onClick={() => toggleActive()}
+								className="cursor-pointer"
+							>
+								{client.active ? (
+									<>
+										<Archive className="mr-2 h-4 w-4" />
+										<span>Deactivate</span>
+									</>
+								) : (
+									<>
+										<ArchiveRestore className="mr-2 h-4 w-4" />
+										<span>Reactivate</span>
+									</>
+								)}
+							</DropdownMenuItem>
 
 							<DropdownMenuItem
 								onClick={() => deleteClient()}

--- a/src/components/invoices/invoice-list.tsx
+++ b/src/components/invoices/invoice-list.tsx
@@ -168,16 +168,35 @@ export default function InvoiceList({ clientId: propClientId }: Props) {
 	const clients = clientsData?.clients ?? [];
 
 	const trpcUtils = trpc.useUtils();
-	const markInvoiceAsMutation = trpc.invoice.updateStatus.useMutation();
+	const sendMutation = trpc.invoice.send.useMutation();
+	const amendMutation = trpc.invoice.amend.useMutation();
+	const markPaidMutation = trpc.invoice.markPaid.useMutation();
+	const unmarkPaidMutation = trpc.invoice.unmarkPaid.useMutation();
 
-	const markInvoiceAs = (invoiceId: string, invoiceStatus: InvoiceStatus) => {
-		if (invoiceId)
-			markInvoiceAsMutation
-				.mutateAsync({ ids: [invoiceId], status: invoiceStatus })
-				.then(() => {
-					trpcUtils.invoice.byId.invalidate({ id: invoiceId });
-					trpcUtils.invoice.list.invalidate();
-				});
+	const invalidateInvoice = (invoiceId: string) => {
+		trpcUtils.invoice.byId.invalidate({ id: invoiceId });
+		trpcUtils.invoice.list.invalidate();
+	};
+
+	// Maps the status the user picked in the dropdown onto the intent-named
+	// transition that gets the invoice there (docs/plans/017 Step 3).
+	const markInvoiceAs = (
+		invoiceId: string,
+		currentStatus: InvoiceStatus,
+		targetStatus: InvoiceStatus
+	) => {
+		const mutation =
+			targetStatus === InvoiceStatus.SENT &&
+			currentStatus === InvoiceStatus.CREATED
+				? sendMutation.mutateAsync({ ids: [invoiceId] })
+				: targetStatus === InvoiceStatus.PAID
+					? markPaidMutation.mutateAsync({ ids: [invoiceId] })
+					: targetStatus === InvoiceStatus.SENT &&
+						  currentStatus === InvoiceStatus.PAID
+						? unmarkPaidMutation.mutateAsync({ ids: [invoiceId] })
+						: amendMutation.mutateAsync({ id: invoiceId });
+
+		mutation.then(() => invalidateInvoice(invoiceId));
 	};
 
 	const hasActiveFilters =
@@ -223,10 +242,12 @@ export default function InvoiceList({ clientId: propClientId }: Props) {
 		{
 			id: "total-cost",
 			accessorFn: (invoice) => {
-				const totalCost = getTotalCostOfActivities(
-					invoice.activities,
-					rateContext
-				);
+				// Locked invoices show the latest version's frozen total, not a
+				// live recompute (docs/plans/017 Step 7/8).
+				const totalCost =
+					invoice.status === InvoiceStatus.CREATED
+						? getTotalCostOfActivities(invoice.activities, rateContext)
+						: (invoice.versions?.[0]?.total ?? 0);
 
 				return totalCost > 0
 					? totalCost.toLocaleString(undefined, {
@@ -258,7 +279,9 @@ export default function InvoiceList({ clientId: propClientId }: Props) {
 							.map((status) => (
 								<DropdownMenuItem
 									key={status}
-									onClick={() => markInvoiceAs(row.original.id, status)}
+									onClick={() =>
+										markInvoiceAs(row.original.id, row.original.status, status)
+									}
 									className="cursor-pointer"
 								>
 									<InvoiceStatusBadge invoiceStatus={status} />

--- a/src/components/invoices/invoice-page.tsx
+++ b/src/components/invoices/invoice-page.tsx
@@ -1,15 +1,23 @@
 import { useRateContext } from "@/components/shared/use-rate-context";
 import { InvoiceStatusBadge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
 import Heading from "@/components/ui/heading";
 import Loading from "@/components/ui/loading";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
+import { downloadOrSharePdf } from "@/lib/download-pdf";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogPanel, Transition } from "@headlessui/react";
 import { InvoiceStatus } from "@/generated/browser";
 import dayjs from "dayjs";
 import {
+	ChevronDown,
 	Clock,
 	DollarSign,
 	Download,
@@ -40,16 +48,51 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 	const { data: invoice, error } = trpc.invoice.byId.useQuery({
 		id: invoiceId
 	});
-	const markInvoiceAsMutation = trpc.invoice.updateStatus.useMutation();
+	const sendMutation = trpc.invoice.send.useMutation();
+	const amendMutation = trpc.invoice.amend.useMutation();
+	const markPaidMutation = trpc.invoice.markPaid.useMutation();
 
-	const markInvoiceAs = (invoiceStatus: InvoiceStatus) => {
-		if (invoiceId)
-			markInvoiceAsMutation
-				.mutateAsync({ ids: [invoiceId], status: invoiceStatus })
-				.then(() => {
-					trpcUtils.invoice.byId.invalidate({ id: invoiceId });
-					trpcUtils.invoice.list.invalidate();
-				});
+	const invalidateInvoice = () => {
+		trpcUtils.invoice.byId.invalidate({ id: invoiceId });
+		trpcUtils.invoice.list.invalidate();
+	};
+
+	const sendInvoice = () => {
+		sendMutation.mutateAsync({ ids: [invoiceId] }).then(invalidateInvoice);
+	};
+
+	const markInvoiceAsPaid = () => {
+		markPaidMutation.mutateAsync({ ids: [invoiceId] }).then(invalidateInvoice);
+	};
+
+	const amendInvoice = () => {
+		if (!confirm("Amend this invoice? It will go back to draft.")) return;
+
+		amendMutation.mutateAsync({ id: invoiceId }).then(invalidateInvoice);
+	};
+
+	// docs/plans/017 Step 7: draft downloads carry a DRAFT watermark; a sent
+	// invoice's download is the frozen version the server resolves.
+	const downloadInvoicePdf = async (versionNumber?: number) => {
+		const dataUrl = await trpcUtils.pdf.forInvoice.fetch({
+			invoiceId,
+			returnBase64: true,
+			versionNumber
+		});
+
+		const displayNo = versionNumber
+			? (invoice?.versions?.find((v) => v.versionNumber === versionNumber)
+					?.displayInvoiceNo ?? invoice?.invoiceNo)
+			: invoice?.invoiceNo;
+
+		await downloadOrSharePdf(dataUrl, `${displayNo}.pdf`);
+	};
+
+	const sendAndDownloadInvoice = () => {
+		sendMutation.mutateAsync({ ids: [invoiceId] }).then(() => {
+			invalidateInvoice();
+			downloadInvoicePdf();
+		});
 	};
 
 	if (error) {
@@ -121,20 +164,24 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 				</div>
 				<div className="mx-auto flex w-full basis-1/2 flex-col px-4 py-4 md:pt-0">
 					<div className="flex items-center justify-between md:mb-5">
-						<Heading className="py-3">{invoice.invoiceNo}</Heading>
-						<Link
-							href={`/dashboard/invoices/${invoice.id}/edit`}
-							className="px-4 py-3 text-sm"
-						>
-							EDIT
-						</Link>
+						<Heading className="py-3">
+							{invoice.versions?.[0]?.displayInvoiceNo ?? invoice.invoiceNo}
+						</Heading>
+						{invoice.status === InvoiceStatus.CREATED && (
+							<Link
+								href={`/dashboard/invoices/${invoice.id}/edit`}
+								className="px-4 py-3 text-sm"
+							>
+								EDIT
+							</Link>
+						)}
 					</div>
 					<p className="text-foreground/80 text-sm">Total</p>
 					<div className="flex items-center justify-between">
 						<p className="text-xl" data-testid="invoice-total">
-							{getTotalCostOfActivities(
-								invoice.activities,
-								rateContext
+							{(invoice.status === InvoiceStatus.CREATED
+								? getTotalCostOfActivities(invoice.activities, rateContext)
+								: (invoice.versions?.[0]?.total ?? 0)
 							).toLocaleString(undefined, {
 								style: "currency",
 								currency: "AUD"
@@ -147,50 +194,64 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 						<div className="mt-5 flex justify-center gap-2">
 							{invoice.status === InvoiceStatus.CREATED &&
 								invoice.activities.length > 0 && (
-									<Button
-										onClick={() => {
-											markInvoiceAs(InvoiceStatus.SENT);
-										}}
-										className="w-1/2 grow"
-									>
+									<Button onClick={sendInvoice} className="w-1/2 grow">
 										<Plane className="mr-2 h-4 w-4" /> Mark as Sent
 									</Button>
 								)}
 							{invoice.status === InvoiceStatus.SENT && (
 								<Button
-									onClick={() => markInvoiceAs(InvoiceStatus.PAID)}
+									onClick={markInvoiceAsPaid}
 									variant="secondary"
 									className="w-1/2 grow"
 								>
 									<DollarSign className="mr-2 h-4 w-4" /> Mark as Paid
 								</Button>
 							)}
-							{invoice.status === InvoiceStatus.PAID && (
+							{(invoice.status === InvoiceStatus.SENT ||
+								invoice.status === InvoiceStatus.PAID) && (
 								<Button
-									onClick={() => {
-										markInvoiceAs("CREATED");
-									}}
+									onClick={amendInvoice}
 									className="w-1/2 grow"
 									variant="secondary"
 								>
 									<Undo className="mr-2 h-4 w-4" />
-									Revert to Created
+									Amend
 								</Button>
 							)}
-							<Button
-								asChild
-								className="w-1/2 grow"
-								variant={
-									invoice.status === InvoiceStatus.CREATED
-										? "secondary"
-										: "default"
-								}
-							>
-								<a href={`/api/invoices/generate-pdf/${invoiceId}`}>
+							{invoice.status === InvoiceStatus.CREATED &&
+							invoice.activities.length > 0 ? (
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button variant="secondary" className="w-1/2 grow">
+											<Download className="mr-2 h-4 w-4" />
+											Download
+											<ChevronDown className="ml-2 h-4 w-4" />
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent>
+										<DropdownMenuItem
+											className="cursor-pointer"
+											onClick={() => downloadInvoicePdf()}
+										>
+											Download draft
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											className="cursor-pointer"
+											onClick={sendAndDownloadInvoice}
+										>
+											Send & download
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+							) : (
+								<Button
+									className="w-1/2 grow"
+									onClick={() => downloadInvoicePdf()}
+								>
 									<Download className="mr-2 h-4 w-4" />
 									Download PDF
-								</a>
-							</Button>
+								</Button>
+							)}
 						</div>
 						{invoice.sentAt && (
 							<div className="text-foreground/80 flex flex-col gap-1">
@@ -200,6 +261,43 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 					</div>
 				</div>
 			</div>
+
+			{invoice.versions && invoice.versions.length > 0 && (
+				<div className="flex w-full flex-col gap-2 p-2 px-4">
+					<p className="font-semibold">Version history</p>
+					{invoice.versions.map((version) => (
+						<div
+							key={version.versionNumber}
+							className="flex items-center justify-between rounded-md border p-3"
+						>
+							<div>
+								<p className="font-semibold">{version.displayInvoiceNo}</p>
+								<p className="text-foreground/60 text-sm">
+									Sent {dayjs.utc(version.sentAt).format("DD/MM/YYYY")}
+									{version.paidAt &&
+										` · Paid ${dayjs.utc(version.paidAt).format("DD/MM/YYYY")}`}
+									{version.backfilled && " · Backfilled"}
+								</p>
+							</div>
+							<div className="flex items-center gap-3">
+								<p className="font-semibold">
+									{version.total.toLocaleString(undefined, {
+										style: "currency",
+										currency: "AUD"
+									})}
+								</p>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={() => downloadInvoicePdf(version.versionNumber)}
+								>
+									<Download className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
 			<div className="flex w-full flex-col justify-between md:flex-row md:pt-6">
 				<div className="flex basis-1/2 flex-col gap-0 p-2 px-4">
 					<p className="font-semibold">Info</p>

--- a/src/components/invoices/log-payment-dialog.tsx
+++ b/src/components/invoices/log-payment-dialog.tsx
@@ -1,4 +1,3 @@
-import { useRateContext } from "@/components/shared/use-rate-context";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -11,7 +10,6 @@ import {
 	DialogTrigger
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { debounce } from "@/lib/generic-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
@@ -23,7 +21,6 @@ import { toast } from "react-toastify";
 const LogPaymentDialog = () => {
 	const [amountPaid, setAmountPaid] = useState(0);
 	const [invoicesToUpdate, setInvoicesToUpdate] = useState<string[]>([]);
-	const rateContext = useRateContext();
 
 	const handleOpenChange = (open: boolean) => {
 		if (!open) {
@@ -44,7 +41,7 @@ const LogPaymentDialog = () => {
 		{ enabled: false }
 	);
 	const trpcUtils = trpc.useUtils();
-	const markInvoiceAsMutation = trpc.invoice.updateStatus.useMutation();
+	const markPaidMutation = trpc.invoice.markPaid.useMutation();
 
 	const updateAmountPaid = debounce(
 		(value: number) => setAmountPaid(value),
@@ -53,10 +50,9 @@ const LogPaymentDialog = () => {
 
 	const updateMatchingInvoices = () => {
 		// Mark matching invoices as paid
-		markInvoiceAsMutation
+		markPaidMutation
 			.mutateAsync({
-				ids: invoicesToUpdate,
-				status: "PAID"
+				ids: invoicesToUpdate
 			})
 			.then(() => {
 				trpcUtils.invoice.list.invalidate();
@@ -106,10 +102,7 @@ const LogPaymentDialog = () => {
 				</div>
 				<div className="ml-auto text-right">
 					<p className="font-semibold">
-						{getTotalCostOfActivities(
-							invoice.activities,
-							rateContext
-						).toLocaleString(undefined, {
+						{invoice.total.toLocaleString(undefined, {
 							style: "currency",
 							currency: "AUD"
 						})}

--- a/src/components/shared/delete-entity-button.tsx
+++ b/src/components/shared/delete-entity-button.tsx
@@ -20,8 +20,12 @@ export const DeleteEntityButton = ({
 				.then(() => {
 					trpcUtils[entityType].list.invalidate();
 				})
-				.catch(() => {
-					toast.error("An error occured. Please refresh and try again.");
+				.catch((error) => {
+					toast.error(
+						error instanceof Error
+							? error.message
+							: "An error occured. Please refresh and try again."
+					);
 				});
 		}
 	};

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -8,7 +8,7 @@ import type {
 	SupportItem,
 	SupportItemRates
 } from "@/generated/client";
-import { getDuration } from "./date-utils";
+import { formatDuration, getDuration } from "./date-utils";
 import { floorToCent, round } from "./generic-utils";
 import {
 	getActivityBasedTransportCode,
@@ -340,4 +340,73 @@ export function billableLines(
 	}
 
 	return lines;
+}
+
+const EXPENSE_TYPE_LABELS: Record<string, string> = {
+	PARKING: "Parking",
+	TOLL: "Toll",
+	OTHER: "Other Transport Expense"
+};
+
+/**
+ * The printed Unit Price column's suffix ("/hr" or "/km"), or `undefined`
+ * for EXPENSE lines (no unit price printed). TRAVEL_TIME follows the
+ * activity's own `rateType`, not this line's `unit` (which is always
+ * MINUTE) — everything else follows `unit` directly. Frozen into
+ * `InvoiceVersion` content at send time (docs/plans/017) alongside
+ * `lineDetailsText` so later changes here don't retroactively alter
+ * historic invoices' rendered text.
+ */
+export function lineUnitPriceSuffix(
+	line: BillableLine,
+	activity: BillableActivity
+): "hr" | "km" | undefined {
+	switch (line.kind) {
+		case "SUPPORT":
+			return line.unit === "HOUR" ? "hr" : "km";
+		case "TRAVEL_TIME":
+			return activity.supportItem.rateType === "HOUR" ? "hr" : "km";
+		case "TRAVEL_KM":
+		case "ABT":
+			return "km";
+		case "EXPENSE":
+			return undefined;
+	}
+}
+
+/**
+ * The printed Details-column text for a line. Frozen into `InvoiceVersion`
+ * content at send time (docs/plans/017) so later changes here don't
+ * retroactively alter historic invoices' rendered text.
+ */
+export function lineDetailsText(
+	line: BillableLine,
+	activity: BillableActivity
+): string {
+	switch (line.kind) {
+		case "SUPPORT": {
+			if (line.unit === "HOUR") {
+				return `${dayjs
+					.utc(activity.startTime ?? undefined)
+					.format("HH:mm")}-${dayjs
+					.utc(activity.endTime ?? undefined)
+					.format("HH:mm")} (${formatDuration(line.quantity)})`;
+			}
+
+			return `${line.quantity} km`;
+		}
+		case "TRAVEL_TIME":
+			return `${line.quantity} minutes`;
+		case "TRAVEL_KM":
+		case "ABT":
+			return `${line.quantity} km`;
+		case "EXPENSE": {
+			const label =
+				EXPENSE_TYPE_LABELS[line.transportType ?? ""] ??
+				line.transportType ??
+				"";
+
+			return `${label}${line.note ? ` - ${line.note}` : ""}`;
+		}
+	}
 }

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -8,6 +8,7 @@ import type {
 	SupportItem,
 	SupportItemRates
 } from "@/generated/client";
+import type { UnitPriceSuffix } from "@/schema/invoice-version-schema";
 import { formatDuration, getDuration } from "./date-utils";
 import { floorToCent, round } from "./generic-utils";
 import {
@@ -360,7 +361,7 @@ const EXPENSE_TYPE_LABELS: Record<string, string> = {
 export function lineUnitPriceSuffix(
 	line: BillableLine,
 	activity: BillableActivity
-): "hr" | "km" | undefined {
+): UnitPriceSuffix | undefined {
 	switch (line.kind) {
 		case "SUPPORT":
 			return line.unit === "HOUR" ? "hr" : "km";

--- a/src/lib/download-pdf.ts
+++ b/src/lib/download-pdf.ts
@@ -1,0 +1,34 @@
+/**
+ * Downloads a PDF, or offers the device's native share sheet when one's
+ * available (mobile browsers) — used for the Step 7 send/download flows
+ * (docs/plans/017).
+ */
+export async function downloadOrSharePdf(
+	base64DataUrl: string,
+	fileName: string
+): Promise<void> {
+	const base64 = base64DataUrl.replace(/^data:application\/pdf;base64,/, "");
+	const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+	const file = new File([bytes], fileName, { type: "application/pdf" });
+
+	if (
+		typeof navigator !== "undefined" &&
+		navigator.share &&
+		navigator.canShare?.({ files: [file] })
+	) {
+		try {
+			await navigator.share({ files: [file], title: fileName });
+			return;
+		} catch {
+			// User cancelled, or the share sheet failed — fall through to a
+			// plain download instead of leaving them with nothing.
+		}
+	}
+
+	const url = URL.createObjectURL(file);
+	const anchor = document.createElement("a");
+	anchor.href = url;
+	anchor.download = fileName;
+	anchor.click();
+	URL.revokeObjectURL(url);
+}

--- a/src/lib/invoice-utils.test.ts
+++ b/src/lib/invoice-utils.test.ts
@@ -1,7 +1,9 @@
 import {
 	getHighestInvoiceNo,
 	getNextInvoiceNo,
-	invoiceCandidatesFromPaymentAmount
+	invoiceCandidatesFromPaymentAmount,
+	invoiceVersionSuffix,
+	displayInvoiceNo
 } from "@/lib/invoice-utils";
 import { expect, test } from "vitest";
 
@@ -107,4 +109,21 @@ test("Should return a single empty combination for payment amount of 0", () => {
 	expect(
 		invoiceCandidatesFromPaymentAmount(0, new Map([[5, "INV-1"]]))
 	).toEqual([[]]);
+});
+
+test("Should derive invoice version display suffixes", () => {
+	expect(invoiceVersionSuffix(1)).toEqual("");
+	expect(invoiceVersionSuffix(2)).toEqual("a");
+	expect(invoiceVersionSuffix(3)).toEqual("b");
+	expect(invoiceVersionSuffix(27)).toEqual("z");
+	expect(invoiceVersionSuffix(28)).toEqual("aa");
+	expect(invoiceVersionSuffix(29)).toEqual("ab");
+	expect(invoiceVersionSuffix(53)).toEqual("az");
+	expect(invoiceVersionSuffix(54)).toEqual("ba");
+});
+
+test("Should build the display invoice number from the stored number + suffix", () => {
+	expect(displayInvoiceNo("INV-001", 1)).toEqual("INV-001");
+	expect(displayInvoiceNo("INV-001", 2)).toEqual("INV-001a");
+	expect(displayInvoiceNo("INV-001", 28)).toEqual("INV-001aa");
 });

--- a/src/lib/invoice-utils.ts
+++ b/src/lib/invoice-utils.ts
@@ -60,6 +60,34 @@ export const getHighestInvoiceNo = (
 	return getNumber(highest) ? highest : undefined;
 };
 
+const SUFFIX_ALPHABET = "abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Version ordinal → display suffix: 1 → "", 2 → "a", 3 → "b" … 27 → "z",
+ * 28 → "aa" (bijective base-26, like spreadsheet column letters).
+ */
+export function invoiceVersionSuffix(versionNumber: number): string {
+	let n = versionNumber - 1;
+	if (n <= 0) return "";
+
+	let suffix = "";
+	while (n > 0) {
+		n -= 1;
+		suffix = SUFFIX_ALPHABET[n % 26] + suffix;
+		n = Math.floor(n / 26);
+	}
+
+	return suffix;
+}
+
+/** The number as printed/downloaded: stored `invoiceNo` + version suffix. */
+export function displayInvoiceNo(
+	invoiceNo: string,
+	versionNumber: number
+): string {
+	return `${invoiceNo}${invoiceVersionSuffix(versionNumber)}`;
+}
+
 export function invoiceCandidatesFromPaymentAmount(
 	paymentAmount: number,
 	invoiceTotals: Map<number, string | string[]>

--- a/src/lib/invoice-version.test.ts
+++ b/src/lib/invoice-version.test.ts
@@ -1,0 +1,79 @@
+import { invoiceVersionContentSchema } from "@/schema/invoice-version-schema";
+import { invoiceFixtures, toRenderInput } from "@/lib/testing/invoice-fixtures";
+import { expect, test } from "vitest";
+import {
+	buildInvoiceVersionContent,
+	formatProviderDetails
+} from "./invoice-version";
+
+test.each(invoiceFixtures)(
+	"builds Zod-valid version content for fixture: $name",
+	(fixture) => {
+		const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+			versionNumber: 1
+		});
+
+		expect(() => invoiceVersionContentSchema.parse(content)).not.toThrow();
+		expect(content.lines.length).toBeGreaterThan(0);
+		expect(content.header.displayInvoiceNo).toEqual(fixture.invoice.invoiceNo);
+	}
+);
+
+test("stamps the amendsDisplayInvoiceNo header field on versions >= 2", () => {
+	const fixture = invoiceFixtures[0];
+
+	const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+		versionNumber: 2,
+		previousDisplayInvoiceNo: fixture.invoice.invoiceNo
+	});
+
+	expect(content.header.displayInvoiceNo).toEqual(
+		`${fixture.invoice.invoiceNo}a`
+	);
+	expect(content.header.amendsDisplayInvoiceNo).toEqual(
+		fixture.invoice.invoiceNo
+	);
+});
+
+test("flags backfilled content", () => {
+	const fixture = invoiceFixtures[0];
+
+	const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+		versionNumber: 1,
+		backfilled: true
+	});
+
+	expect(content.backfilled).toBe(true);
+});
+
+test("total equals the sum of line totals", () => {
+	const fixture = invoiceFixtures.find((f) => f.name === "kitchen-sink")!;
+
+	const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+		versionNumber: 1
+	});
+
+	const expectedTotal = content.lines.reduce(
+		(sum, line) => sum + line.total,
+		0
+	);
+	expect(content.total).toBeCloseTo(expectedTotal, 2);
+});
+
+test("formatProviderDetails matches the PDF's printed grouping", () => {
+	const fixture = invoiceFixtures.find((f) => f.name === "kitchen-sink")!;
+
+	const provider = formatProviderDetails(fixture.user);
+
+	expect(provider.abn).toEqual("12 345 678 901");
+	expect(provider.bsb).toEqual("123-456");
+	expect(provider.accountNumber).toEqual("987 654 321");
+});
+
+test("formatProviderDetails omits fields when the user is missing bank details", () => {
+	const fixture = invoiceFixtures.find((f) => f.name === "no-payment-footer")!;
+
+	const provider = formatProviderDetails(fixture.user);
+
+	expect(provider.bankName).toBeUndefined();
+});

--- a/src/lib/invoice-version.ts
+++ b/src/lib/invoice-version.ts
@@ -1,0 +1,112 @@
+import {
+	invoiceVersionContentSchema,
+	type InvoiceVersionContent,
+	type InvoiceVersionLine
+} from "@/schema/invoice-version-schema";
+import {
+	billableLines,
+	lineDetailsText,
+	lineUnitPriceSuffix
+} from "./billing-lines";
+import { round } from "./generic-utils";
+import { displayInvoiceNo } from "./invoice-utils";
+import type { InvoicePdfData } from "./pdf-generation";
+
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+dayjs.extend(utc);
+
+const groupDigits = (value: string, separator: string) =>
+	value.replaceAll(/\B(?=(\d{3})+(?!\d))/g, separator);
+
+export interface ProviderDetails {
+	name?: string;
+	abn?: string;
+	bankName?: string;
+	bsb?: string;
+	accountNumber?: string;
+}
+
+/**
+ * The provider/payment-footer fields exactly as the PDF prints them —
+ * shared by the live render and the frozen `InvoiceVersion` builder so the
+ * two paths can never drift (docs/plans/017 Step 2).
+ */
+export function formatProviderDetails(
+	user: InvoicePdfData["user"]
+): ProviderDetails {
+	if (!user) return {};
+
+	return {
+		...(user.name ? { name: user.name } : {}),
+		...(user.abn ? { abn: groupDigits(user.abn.toString(), " ") } : {}),
+		...(user.bankName ? { bankName: user.bankName } : {}),
+		...(user.bsb ? { bsb: groupDigits(user.bsb.toString(), "-") } : {}),
+		...(user.bankNumber
+			? { accountNumber: groupDigits(user.bankNumber.toString(), " ") }
+			: {})
+	};
+}
+
+export interface BuildInvoiceVersionContentOptions {
+	versionNumber: number;
+	previousDisplayInvoiceNo?: string;
+	backfilled?: boolean;
+}
+
+/** Pure builder from plan 007's PDF loader output to the frozen snapshot shape. */
+export function buildInvoiceVersionContent(
+	data: InvoicePdfData,
+	options: BuildInvoiceVersionContentOptions
+): InvoiceVersionContent {
+	const { invoice, user, rateContext } = data;
+	const { versionNumber, previousDisplayInvoiceNo, backfilled } = options;
+
+	const lines: InvoiceVersionLine[] = invoice.activities
+		.filter((activity) => activity.supportItem !== null)
+		.flatMap((activity) =>
+			billableLines(activity, rateContext).map((line) => ({
+				kind: line.kind,
+				description: line.description,
+				supportItemCode: line.supportItemCode,
+				serviceDate: dayjs.utc(line.serviceDate).toISOString(),
+				quantity: line.quantity,
+				unit: line.unit,
+				unitPrice: line.unitPrice,
+				total: line.total,
+				...(line.activityId ? { activityId: line.activityId } : {}),
+				detailsText: lineDetailsText(line, activity),
+				...(lineUnitPriceSuffix(line, activity)
+					? { unitPriceSuffix: lineUnitPriceSuffix(line, activity) }
+					: {})
+			}))
+		);
+
+	const total = round(
+		lines.reduce((sum, line) => sum + line.total, 0),
+		2
+	);
+
+	const content: InvoiceVersionContent = {
+		schemaVersion: 1,
+		...(backfilled ? { backfilled: true } : {}),
+		header: {
+			invoiceNo: invoice.invoiceNo,
+			displayInvoiceNo: displayInvoiceNo(invoice.invoiceNo, versionNumber),
+			date: dayjs.utc(invoice.date).toISOString(),
+			participantName: invoice.client?.name ?? "",
+			...(invoice.client?.number
+				? { participantNumber: invoice.client.number }
+				: {}),
+			...(invoice.billTo ? { billTo: invoice.billTo } : {}),
+			...(previousDisplayInvoiceNo
+				? { amendsDisplayInvoiceNo: previousDisplayInvoiceNo }
+				: {})
+		},
+		provider: formatProviderDetails(user),
+		lines,
+		total
+	};
+
+	return invoiceVersionContentSchema.parse(content);
+}

--- a/src/lib/invoice-version.ts
+++ b/src/lib/invoice-version.ts
@@ -65,21 +65,23 @@ export function buildInvoiceVersionContent(
 	const lines: InvoiceVersionLine[] = invoice.activities
 		.filter((activity) => activity.supportItem !== null)
 		.flatMap((activity) =>
-			billableLines(activity, rateContext).map((line) => ({
-				kind: line.kind,
-				description: line.description,
-				supportItemCode: line.supportItemCode,
-				serviceDate: dayjs.utc(line.serviceDate).toISOString(),
-				quantity: line.quantity,
-				unit: line.unit,
-				unitPrice: line.unitPrice,
-				total: line.total,
-				...(line.activityId ? { activityId: line.activityId } : {}),
-				detailsText: lineDetailsText(line, activity),
-				...(lineUnitPriceSuffix(line, activity)
-					? { unitPriceSuffix: lineUnitPriceSuffix(line, activity) }
-					: {})
-			}))
+			billableLines(activity, rateContext).map((line) => {
+				const unitPriceSuffix = lineUnitPriceSuffix(line, activity);
+
+				return {
+					kind: line.kind,
+					description: line.description,
+					supportItemCode: line.supportItemCode,
+					serviceDate: dayjs.utc(line.serviceDate).toISOString(),
+					quantity: line.quantity,
+					unit: line.unit,
+					unitPrice: line.unitPrice,
+					total: line.total,
+					...(line.activityId ? { activityId: line.activityId } : {}),
+					detailsText: lineDetailsText(line, activity),
+					...(unitPriceSuffix ? { unitPriceSuffix } : {})
+				};
+			})
 		);
 
 	const total = round(

--- a/src/lib/pdf-generation.integration.test.ts
+++ b/src/lib/pdf-generation.integration.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+import prisma from "@/server/prisma";
+import generatePDF, { renderInvoiceVersionPdf } from "@/lib/pdf-generation";
+import { extractPdfText } from "@/lib/testing/pdf-test-utils";
+import { invoiceVersionContentSchema } from "@/schema/invoice-version-schema";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../server/api/test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function setupSentInvoice(
+	user: Awaited<ReturnType<typeof createTestUser>>
+) {
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Jane Citizen", transitRatePerKm: "0.5" }
+	});
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0,
+			transitDistance: "15",
+			transitDuration: "30"
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-STABLE",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	return { caller, client, supportItem, activity, invoice };
+}
+
+test("clean render of a sent invoice is byte-stable across every upstream mutation (docs/plans/017 Step 6 headline)", async () => {
+	const user = await createTestUser();
+	const { supportItem, client, activity, invoice } =
+		await setupSentInvoice(user);
+
+	const before = await generatePDF(invoice.id, user.id);
+	const textBefore = await extractPdfText(before.pdfString);
+	expect(textBefore).toContain("$100.00/hr");
+
+	await prisma.supportItem.update({
+		where: { id: supportItem.id },
+		data: { weekdayRate: 999 }
+	});
+	await prisma.client.update({
+		where: { id: client.id },
+		data: { transitRatePerKm: 5 }
+	});
+	await prisma.user.update({
+		where: { id: user.id },
+		data: { transitRatePerKm: 5, bankName: "Mutated Bank", bsb: 999999 }
+	});
+	await prisma.activity.update({
+		where: { id: activity.id },
+		data: {
+			startTime: new Date("1970-01-01T05:00:00.000Z"),
+			endTime: new Date("1970-01-01T09:00:00.000Z")
+		}
+	});
+
+	const after = await generatePDF(invoice.id, user.id);
+	const textAfter = await extractPdfText(after.pdfString);
+
+	expect(textAfter).toEqual(textBefore);
+	expect(textAfter).not.toContain("999.00");
+	expect(textAfter).not.toContain("Mutated Bank");
+});
+
+test("a draft invoice's clean-looking render carries the DRAFT watermark and reads live data", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 50,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-DRAFT",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	const { pdfString, fileName } = await generatePDF(invoice.id, user.id);
+	const text = await extractPdfText(pdfString);
+
+	expect(fileName).toBe("INV-DRAFT.pdf");
+	expect(text).toContain("DRAFT");
+	expect(text).toContain("$50.00/hr");
+
+	await prisma.supportItem.update({
+		where: { id: supportItem.id },
+		data: { weekdayRate: 75 }
+	});
+
+	const { pdfString: pdfStringAfter } = await generatePDF(invoice.id, user.id);
+	const textAfter = await extractPdfText(pdfStringAfter);
+
+	// A draft has no frozen content — it's expected to reflect live data.
+	expect(textAfter).toContain("$75.00/hr");
+});
+
+test("amend then re-send renders the v2 supersedes line and INV-1a filename", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupSentInvoice(user);
+
+	await caller.invoice.amend({ id: invoice.id });
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	const { pdfString, fileName } = await generatePDF(invoice.id, user.id);
+	const text = await extractPdfText(pdfString);
+
+	expect(fileName).toBe("INV-STABLEa.pdf");
+	expect(text).toContain("This invoice amends and supersedes INV-STABLE");
+
+	const v1 = await generatePDF(invoice.id, user.id, { versionNumber: 1 });
+	expect(v1.fileName).toBe("INV-STABLE.pdf");
+	const v1Text = await extractPdfText(v1.pdfString);
+	expect(v1Text).not.toContain("supersedes");
+});
+
+test("renderInvoiceVersionPdf parses stored content through the Zod schema", async () => {
+	const user = await createTestUser();
+	const { invoice } = await setupSentInvoice(user);
+
+	const version = await prisma.invoiceVersion.findFirstOrThrow({
+		where: { invoiceId: invoice.id, versionNumber: 1 }
+	});
+	const content = invoiceVersionContentSchema.parse(version.content);
+
+	const { pdfString, fileName } = renderInvoiceVersionPdf(content);
+
+	expect(fileName).toBe("INV-STABLE.pdf");
+	expect(pdfString.length).toBeGreaterThan(0);
+});
+
+test("requesting a version number that doesn't exist returns no PDF", async () => {
+	const user = await createTestUser();
+	const { invoice } = await setupSentInvoice(user);
+
+	const result = await generatePDF(invoice.id, user.id, { versionNumber: 7 });
+
+	expect(result.fileName).toBeNull();
+	expect(result.pdfString).toBe("");
+});

--- a/src/lib/pdf-generation.ts
+++ b/src/lib/pdf-generation.ts
@@ -12,7 +12,8 @@ import { formatProviderDetails, type ProviderDetails } from "./invoice-version";
 import { round } from "./generic-utils";
 import {
 	invoiceVersionContentSchema,
-	type InvoiceVersionContent
+	type InvoiceVersionContent,
+	type UnitPriceSuffix
 } from "@/schema/invoice-version-schema";
 
 import dayjs from "dayjs";
@@ -96,7 +97,7 @@ interface PdfLine {
 	serviceDate: Date | string;
 	total: number;
 	unitPrice: number;
-	unitPriceSuffix?: "hr" | "km";
+	unitPriceSuffix?: UnitPriceSuffix;
 	detailsText: string;
 }
 

--- a/src/lib/pdf-generation.ts
+++ b/src/lib/pdf-generation.ts
@@ -1,14 +1,19 @@
 import prisma from "@/server/prisma";
-import { RateType, type User } from "@/generated/client";
+import type { Prisma, User } from "@/generated/client";
 import jspdf from "jspdf";
 import autoTable, { CellDef } from "jspdf-autotable";
 import {
 	type BillableActivity,
-	type BillableLine,
-	billableLines
+	billableLines,
+	lineDetailsText,
+	lineUnitPriceSuffix
 } from "./billing-lines";
-import { formatDuration } from "./date-utils";
+import { formatProviderDetails, type ProviderDetails } from "./invoice-version";
 import { round } from "./generic-utils";
+import {
+	invoiceVersionContentSchema,
+	type InvoiceVersionContent
+} from "@/schema/invoice-version-schema";
 
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
@@ -31,18 +36,22 @@ export interface InvoicePdfData {
 	rateContext: { userTransitRatePerKm: number };
 }
 
+/** The subset of a Prisma client/transaction client the loader needs. */
+type PdfPrismaClient = Pick<Prisma.TransactionClient, "invoice" | "user">;
+
 export const loadInvoiceForPdf = async (
 	invoiceId: string,
-	ownerId: string
+	ownerId: string,
+	client: PdfPrismaClient = prisma
 ): Promise<InvoicePdfData | null> => {
-	const invoiceRecord = await prisma.invoice.findFirst({
+	const invoiceRecord = await client.invoice.findFirst({
 		where: { id: invoiceId, ownerId },
 		select: { clientId: true }
 	});
 
 	if (!invoiceRecord?.clientId) return null;
 
-	const invoice = await prisma.invoice.findFirst({
+	const invoice = await client.invoice.findFirst({
 		where: { id: invoiceId, ownerId },
 		include: {
 			client: true,
@@ -62,7 +71,7 @@ export const loadInvoiceForPdf = async (
 
 	if (!invoice || !invoice.client || !invoice.activities) return null;
 
-	const user = await prisma.user.findUnique({ where: { id: invoice.ownerId } });
+	const user = await client.user.findUnique({ where: { id: invoice.ownerId } });
 
 	return {
 		invoice,
@@ -73,90 +82,60 @@ export const loadInvoiceForPdf = async (
 	};
 };
 
-/** The Details-column cell for a line, plus its Unit Price suffix. */
-const formatLine = (
-	line: BillableLine,
-	activity: BillableActivity
-): string[] => {
+/**
+ * A single printed table row's worth of data, already resolved to exactly
+ * what's printed — no `kind`-specific branching left to do, and no live
+ * `Activity` reference needed. Both rendering sources (live activities via
+ * plan 007's `billableLines`, and a frozen `InvoiceVersion.content`) build
+ * this shape so the drawing code below is source-agnostic (docs/plans/017
+ * Step 6).
+ */
+interface PdfLine {
+	description: string;
+	supportItemCode: string;
+	serviceDate: Date | string;
+	total: number;
+	unitPrice: number;
+	unitPriceSuffix?: "hr" | "km";
+	detailsText: string;
+}
+
+/** The Details-column cell for a line, plus its Unit Price column. */
+const formatPdfLine = (line: PdfLine): string[] => {
 	const dateCell = `${dayjs.utc(line.serviceDate).format("DD/MM/YY")}\n`;
 	const descriptionCell = `${line.description}\n${line.supportItemCode}\n`;
 	const totalCell = `$${line.total.toFixed(2)}\n`;
+	const detailsCell = `${line.detailsText}\n`;
+	const unitPriceCell = line.unitPriceSuffix
+		? `$${line.unitPrice.toFixed(2)}/${line.unitPriceSuffix}\n`
+		: `-\n`;
 
-	switch (line.kind) {
-		case "SUPPORT": {
-			if (line.unit === "HOUR") {
-				const detailsCell = `${dayjs
-					.utc(activity.startTime ?? undefined)
-					.format("HH:mm")}-${dayjs
-					.utc(activity.endTime ?? undefined)
-					.format("HH:mm")} (${formatDuration(line.quantity)})\n`;
-
-				return [
-					descriptionCell,
-					dateCell,
-					detailsCell,
-					`$${line.unitPrice.toFixed(2)}/hr\n`,
-					totalCell
-				];
-			}
-
-			return [
-				descriptionCell,
-				dateCell,
-				`${line.quantity} km\n`,
-				`$${line.unitPrice.toFixed(2)}/km\n`,
-				totalCell
-			];
-		}
-		case "TRAVEL_TIME": {
-			// Matches the printed unit-price suffix historically: it follows the
-			// activity's own rateType, not this line's unit (docs/plans/007).
-			const suffix =
-				activity.supportItem.rateType === RateType.HOUR ? "hr" : "km";
-
-			return [
-				descriptionCell,
-				dateCell,
-				`${line.quantity} minutes\n`,
-				`$${line.unitPrice.toFixed(2)}/${suffix}\n`,
-				totalCell
-			];
-		}
-		case "TRAVEL_KM":
-		case "ABT": {
-			return [
-				descriptionCell,
-				dateCell,
-				`${line.quantity} km\n`,
-				`$${line.unitPrice.toFixed(2)}/km\n`,
-				totalCell
-			];
-		}
-		case "EXPENSE": {
-			const typeLabels: Record<string, string> = {
-				PARKING: "Parking",
-				TOLL: "Toll",
-				OTHER: "Other Transport Expense"
-			};
-			const label =
-				typeLabels[line.transportType ?? ""] ?? line.transportType ?? "";
-
-			return [
-				descriptionCell,
-				dateCell,
-				`${label}${line.note ? ` - ${line.note}` : ""}\n`,
-				`-\n`,
-				totalCell
-			];
-		}
-	}
+	return [descriptionCell, dateCell, detailsCell, unitPriceCell, totalCell];
 };
 
-export const renderInvoicePdf = (
-	data: InvoicePdfData
-): { pdfString: string; fileName: string } => {
-	const { invoice, user, rateContext } = data;
+/**
+ * Everything `renderFromRenderable` needs to draw a PDF — built either from
+ * live `InvoicePdfData` (draft, watermarked) or a frozen
+ * `InvoiceVersionContent` (clean, possibly with a supersedes line).
+ */
+interface RenderableInvoice {
+	invoiceNoLabel: string;
+	date: Date | string;
+	participantName: string;
+	participantNumber?: string | null;
+	billTo?: string | null;
+	/** The previous version's display number, printed as a supersedes line. */
+	supersedesLabel?: string;
+	lines: PdfLine[];
+	total: number;
+	provider: ProviderDetails;
+	fileName: string;
+	watermark?: "DRAFT";
+}
 
+const renderFromRenderable = (
+	renderable: RenderableInvoice
+): { pdfString: string; fileName: string } => {
 	const margin = 20;
 
 	const document_ = new jspdf();
@@ -170,13 +149,17 @@ export const renderInvoicePdf = (
 
 	// Write details at top of page
 	const invoiceDetails: string[] = [
-		`Invoice Number: ${invoice.invoiceNo}`,
-		`Invoice Date: ${dayjs(invoice.date).format("DD/MM/YY")}`,
-		`Participant Name: ${invoice.client?.name}`
+		`Invoice Number: ${renderable.invoiceNoLabel}`,
+		`Invoice Date: ${dayjs(renderable.date).format("DD/MM/YY")}`,
+		`Participant Name: ${renderable.participantName}`
 	];
-	if (invoice.client?.number)
-		invoiceDetails.push(`Participant Number: ${invoice.client?.number}`);
-	if (invoice.billTo) invoiceDetails.push(`Bill To: ${invoice.billTo}`);
+	if (renderable.participantNumber)
+		invoiceDetails.push(`Participant Number: ${renderable.participantNumber}`);
+	if (renderable.billTo) invoiceDetails.push(`Bill To: ${renderable.billTo}`);
+	if (renderable.supersedesLabel)
+		invoiceDetails.push(
+			`This invoice amends and supersedes ${renderable.supersedesLabel}`
+		);
 
 	for (const [index, detail] of invoiceDetails.entries()) {
 		document_.text(detail, margin, margin + index * 5);
@@ -187,25 +170,13 @@ export const renderInvoicePdf = (
 		cells: string[];
 	}
 
-	const rows: Row[] = [];
-	const allLines: BillableLine[] = [];
-
-	for (const activity of invoice.activities) {
-		if (activity?.supportItem === null) continue;
-
-		const lines = billableLines(activity, rateContext);
-		allLines.push(...lines);
-
-		for (const line of lines) {
-			rows.push({
-				// ABT and EXPENSE lines for the same activity share one printed
-				// "Activity Based Transport" row (see formatLine), so the merge
-				// key is the description cell's content, not the line's kind.
-				key: `${line.supportItemCode}::${line.description}`,
-				cells: formatLine(line, activity)
-			});
-		}
-	}
+	const rows: Row[] = renderable.lines.map((line) => ({
+		// ABT and EXPENSE lines for the same activity share one printed
+		// "Activity Based Transport" row (see formatPdfLine), so the merge
+		// key is the description cell's content, not the line's kind.
+		key: `${line.supportItemCode}::${line.description}`,
+		cells: formatPdfLine(line)
+	}));
 
 	// Sort rows based on description
 	rows.sort((a, b) => {
@@ -236,11 +207,6 @@ export const renderInvoicePdf = (
 	// Activities only allows strings - need to allow strings and CellDef
 	const values: (CellDef | string)[][] = activityStrings;
 
-	const grandTotal = round(
-		allLines.reduce((total, line) => total + line.total, 0),
-		2
-	);
-
 	// Bottom section
 	values.push(
 		[
@@ -250,51 +216,46 @@ export const renderInvoicePdf = (
 				styles: { fontStyle: "bold", halign: "right" }
 			},
 			{
-				content: `$${grandTotal.toFixed(2)}`,
+				content: `$${renderable.total.toFixed(2)}`,
 				styles: { fontStyle: "bold" }
 			}
 		],
 		[{ content: "", colSpan: 5, styles: { fillColor: "#fff" } }]
 	);
 
-	if (user) {
-		const content = [
-			user.name ?? "",
-			user.abn
-				? `ABN: ${user.abn.toString().replaceAll(/\B(?=(\d{3})+(?!\d))/g, " ")}`
-				: "",
-			user.bankName ? `Bank: ${user.bankName}` : "",
-			user.bsb
-				? `BSB: ${user.bsb.toString().replaceAll(/\B(?=(\d{3})+(?!\d))/g, "-")}`
-				: "",
-			user.bankNumber
-				? `Account Number: ${user.bankNumber
-						?.toString()
-						.replaceAll(/\B(?=(\d{3})+(?!\d))/g, " ")}`
-				: ""
-		].filter((val) => val.length > 0);
+	const providerLines = [
+		renderable.provider.name ?? "",
+		renderable.provider.abn ? `ABN: ${renderable.provider.abn}` : "",
+		renderable.provider.bankName ? `Bank: ${renderable.provider.bankName}` : "",
+		renderable.provider.bsb ? `BSB: ${renderable.provider.bsb}` : "",
+		renderable.provider.accountNumber
+			? `Account Number: ${renderable.provider.accountNumber}`
+			: ""
+	].filter((val) => val.length > 0);
 
-		if (content.length === 5) {
-			values.push([
-				{
-					content: content.join("\n"),
-					colSpan: 5,
-					rowSpan: 2,
-					styles: {
-						minCellHeight: 46,
-						halign: "left",
-						fillColor: "#FFF",
-						fontStyle: "bold",
-						lineWidth: 0.2,
-						lineColor: "#000"
-					}
+	if (providerLines.length === 5) {
+		values.push([
+			{
+				content: providerLines.join("\n"),
+				colSpan: 5,
+				rowSpan: 2,
+				styles: {
+					minCellHeight: 46,
+					halign: "left",
+					fillColor: "#FFF",
+					fontStyle: "bold",
+					lineWidth: 0.2,
+					lineColor: "#000"
 				}
-			]);
-		}
+			}
+		]);
 	}
 
 	const startY =
-		35 + (invoice.billTo ? 5 : 0) + (invoice.client?.number ? 5 : 0);
+		35 +
+		(renderable.billTo ? 5 : 0) +
+		(renderable.participantNumber ? 5 : 0) +
+		(renderable.supersedesLabel ? 5 : 0);
 
 	autoTable(document_, {
 		head: [
@@ -333,22 +294,139 @@ export const renderInvoicePdf = (
 		}
 	});
 
-	const fileName = `${invoice.invoiceNo}.pdf`;
+	if (renderable.watermark === "DRAFT") {
+		document_.saveGraphicsState();
+		document_.setGState(document_.GState({ opacity: 0.15 }));
+		document_.setFontSize(80);
+		document_.setTextColor(150, 150, 150);
+		document_.text("DRAFT", 105, 180, { angle: 45, align: "center" });
+		document_.restoreGraphicsState();
+	}
 
 	return {
 		pdfString: document_
 			.output("dataurlstring")
 			.replace(/^data:application\/pdf;filename=.+\.pdf;base64,/, ""),
-		fileName
+		fileName: renderable.fileName
 	};
 };
 
-const generatePDF = async (invoiceId: string, ownerId: string) => {
+/** Renders live data — used only for drafts, so callers should pass `draftWatermark: true`. */
+export const renderInvoicePdf = (
+	data: InvoicePdfData,
+	options: { draftWatermark?: boolean } = {}
+): { pdfString: string; fileName: string } => {
+	const { invoice, user, rateContext } = data;
+
+	const lines: PdfLine[] = [];
+
+	for (const activity of invoice.activities) {
+		if (activity?.supportItem === null) continue;
+
+		for (const line of billableLines(activity, rateContext)) {
+			lines.push({
+				description: line.description,
+				supportItemCode: line.supportItemCode,
+				serviceDate: line.serviceDate,
+				total: line.total,
+				unitPrice: line.unitPrice,
+				unitPriceSuffix: lineUnitPriceSuffix(line, activity),
+				detailsText: lineDetailsText(line, activity)
+			});
+		}
+	}
+
+	const total = round(
+		lines.reduce((sum, line) => sum + line.total, 0),
+		2
+	);
+
+	return renderFromRenderable({
+		invoiceNoLabel: invoice.invoiceNo,
+		date: invoice.date,
+		participantName: invoice.client?.name ?? "",
+		participantNumber: invoice.client?.number,
+		billTo: invoice.billTo,
+		lines,
+		total,
+		provider: formatProviderDetails(user),
+		fileName: `${invoice.invoiceNo}.pdf`,
+		watermark: options.draftWatermark ? "DRAFT" : undefined
+	});
+};
+
+/**
+ * Renders a frozen `InvoiceVersion.content` document — no live reads, so a
+ * sent/paid invoice's clean PDF renders byte-identically no matter what
+ * changes upstream afterwards (docs/plans/017 Step 6).
+ */
+export const renderInvoiceVersionPdf = (
+	content: InvoiceVersionContent
+): { pdfString: string; fileName: string } =>
+	renderFromRenderable({
+		invoiceNoLabel: content.header.displayInvoiceNo,
+		date: content.header.date,
+		participantName: content.header.participantName,
+		participantNumber: content.header.participantNumber,
+		billTo: content.header.billTo,
+		supersedesLabel: content.header.amendsDisplayInvoiceNo,
+		lines: content.lines,
+		total: content.total,
+		provider: content.provider,
+		fileName: `${content.header.displayInvoiceNo}.pdf`
+	});
+
+export interface GeneratePdfOptions {
+	/** Render this specific version instead of resolving by invoice status. */
+	versionNumber?: number;
+}
+
+/**
+ * Resolves which of the two data sources above to render from
+ * (docs/plans/017 Step 6): an explicit version number always wins; failing
+ * that, a locked (non-draft) invoice renders its latest version; a draft
+ * invoice renders live data with the DRAFT watermark.
+ */
+const generatePDF = async (
+	invoiceId: string,
+	ownerId: string,
+	options: GeneratePdfOptions = {}
+): Promise<{ pdfString: string; fileName: string | null }> => {
+	const invoice = await prisma.invoice.findFirst({
+		where: { id: invoiceId, ownerId },
+		select: { status: true }
+	});
+
+	if (!invoice) return { pdfString: "", fileName: null };
+
+	if (options.versionNumber !== undefined) {
+		const version = await prisma.invoiceVersion.findFirst({
+			where: { invoiceId, versionNumber: options.versionNumber }
+		});
+		if (!version) return { pdfString: "", fileName: null };
+
+		return renderInvoiceVersionPdf(
+			invoiceVersionContentSchema.parse(version.content)
+		);
+	}
+
+	if (invoice.status !== "CREATED") {
+		const latestVersion = await prisma.invoiceVersion.findFirst({
+			where: { invoiceId },
+			orderBy: { versionNumber: "desc" }
+		});
+		if (!latestVersion) return { pdfString: "", fileName: null };
+
+		return renderInvoiceVersionPdf(
+			invoiceVersionContentSchema.parse(latestVersion.content)
+		);
+	}
+
 	const data = await loadInvoiceForPdf(invoiceId, ownerId);
 
 	if (!data) return { pdfString: "", fileName: null };
 
-	return renderInvoicePdf(data);
+	return renderInvoicePdf(data, { draftWatermark: true });
 };
 
 export default generatePDF;

--- a/src/lib/pdf-generation.version.test.ts
+++ b/src/lib/pdf-generation.version.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import {
+	renderInvoicePdf,
+	renderInvoiceVersionPdf
+} from "@/lib/pdf-generation";
+import { buildInvoiceVersionContent } from "@/lib/invoice-version";
+import { getFixture, toRenderInput } from "@/lib/testing/invoice-fixtures";
+import { extractPdfText } from "@/lib/testing/pdf-test-utils";
+import { describe, expect, test } from "vitest";
+
+// pdfjs breaks under the project-default jsdom environment, hence the
+// node environment directive above (docs/plans/017 Step 6).
+
+describe("draft (live) rendering", () => {
+	test("no watermark by default", async () => {
+		const fixture = getFixture("kitchen-sink");
+
+		const { pdfString } = renderInvoicePdf(toRenderInput(fixture));
+		const text = await extractPdfText(pdfString);
+
+		expect(text).not.toContain("DRAFT");
+	});
+
+	test("draftWatermark: true overlays DRAFT without changing the line data", async () => {
+		const fixture = getFixture("kitchen-sink");
+
+		const { pdfString } = renderInvoicePdf(toRenderInput(fixture), {
+			draftWatermark: true
+		});
+		const text = await extractPdfText(pdfString);
+
+		expect(text).toContain("DRAFT");
+		expect(text).toContain("$720.77");
+	});
+});
+
+describe("frozen version rendering", () => {
+	test("v1 prints the plain invoice number, no supersedes line", async () => {
+		const fixture = getFixture("kitchen-sink");
+		const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+			versionNumber: 1
+		});
+
+		const { pdfString, fileName } = renderInvoiceVersionPdf(content);
+		const text = await extractPdfText(pdfString);
+
+		expect(fileName).toBe("SINK-1.pdf");
+		expect(text).toContain("Invoice Number: SINK-1");
+		expect(text).not.toContain("supersedes");
+		expect(text).not.toContain("DRAFT");
+	});
+
+	test("v2 prints the suffixed display number and the supersedes line", async () => {
+		const fixture = getFixture("kitchen-sink");
+		const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+			versionNumber: 2,
+			previousDisplayInvoiceNo: "SINK-1"
+		});
+
+		const { pdfString, fileName } = renderInvoiceVersionPdf(content);
+		const text = await extractPdfText(pdfString);
+
+		expect(fileName).toBe("SINK-1a.pdf");
+		expect(text).toContain("Invoice Number: SINK-1a");
+		expect(text).toContain("This invoice amends and supersedes SINK-1");
+	});
+
+	test("renders byte-identically to the live golden text for the same data", async () => {
+		const fixture = getFixture("kitchen-sink");
+		const content = buildInvoiceVersionContent(toRenderInput(fixture), {
+			versionNumber: 1
+		});
+
+		const live = renderInvoicePdf(toRenderInput(fixture));
+		const version = renderInvoiceVersionPdf(content);
+
+		const liveText = await extractPdfText(live.pdfString);
+		const versionText = await extractPdfText(version.pdfString);
+
+		expect(versionText).toEqual(liveText);
+	});
+});

--- a/src/lib/testing/invoice-fixtures.ts
+++ b/src/lib/testing/invoice-fixtures.ts
@@ -85,6 +85,7 @@ const makeClient = (
 	name: "Jane Citizen",
 	number: null,
 	invoiceEmail: null,
+	active: true,
 	distanceToClient: null,
 	travelTimeToClient: null,
 	transitRatePerKm: null,

--- a/src/pages/api/invoices/generate-pdf/[id].ts
+++ b/src/pages/api/invoices/generate-pdf/[id].ts
@@ -15,11 +15,14 @@ const request = async (request: NextApiRequest, response: NextApiResponse) => {
 		return response.status(401).send("Unauthorized");
 	}
 
-	const { id, base64 } = request.query;
+	const { id, base64, versionNumber } = request.query;
 
 	const { pdfString, fileName } = await generatePDF(
 		String(id),
-		session.user.id
+		session.user.id,
+		{
+			versionNumber: versionNumber ? Number(versionNumber) : undefined
+		}
 	);
 
 	if (!pdfString) {

--- a/src/pages/dashboard/invoices/[id]/edit.tsx
+++ b/src/pages/dashboard/invoices/[id]/edit.tsx
@@ -2,9 +2,11 @@ import Loading from "@/components/ui/loading";
 import InvoiceForm from "@/components/invoices/invoice-form";
 import Layout from "@/components/shared/layout";
 import { InvoiceSchema } from "@/schema/invoice-schema";
+import { InvoiceStatus } from "@/generated/browser";
 import { trpc } from "@/lib/trpc";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { toast } from "react-toastify";
 
 const EditInvoice = () => {
@@ -20,6 +22,14 @@ const EditInvoice = () => {
 		id: invoiceId ?? ""
 	});
 
+	// A sent/paid invoice is locked (docs/plans/017 Step 4) — amend it
+	// first rather than editing it directly.
+	useEffect(() => {
+		if (invoice && invoice.status !== InvoiceStatus.CREATED) {
+			router.replace(`/dashboard/invoices/${invoice.id}`);
+		}
+	}, [invoice, router]);
+
 	if (error) {
 		return (
 			<Layout>
@@ -28,7 +38,7 @@ const EditInvoice = () => {
 		);
 	}
 
-	if (!invoice) {
+	if (!invoice || invoice.status !== InvoiceStatus.CREATED) {
 		return (
 			<Layout>
 				<Loading />

--- a/src/schema/client-schema.ts
+++ b/src/schema/client-schema.ts
@@ -9,6 +9,7 @@ export const clientSchema = z.object({
 	distanceToClient: z.string().optional(),
 	travelTimeToClient: z.string().optional(),
 	transitRatePerKm: z.string().optional(),
-	invoiceEmail: z.string().optional()
+	invoiceEmail: z.string().optional(),
+	active: z.boolean().optional()
 });
 export type ClientSchema = z.infer<typeof clientSchema>;

--- a/src/schema/invoice-version-schema.ts
+++ b/src/schema/invoice-version-schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/**
+ * The frozen shape of an `InvoiceVersion.content` jsonb document (docs/adr/0004,
+ * docs/plans/017). Every read of `content` parses through this schema.
+ *
+ * `schemaVersion` is the evolution mechanism: add new fields as optional; a
+ * breaking shape change bumps the literal and the renderer branches on it.
+ * Never rewrite stored content to match a newer schema version.
+ */
+export const invoiceVersionLineSchema = z.object({
+	kind: z.enum(["SUPPORT", "TRAVEL_TIME", "TRAVEL_KM", "ABT", "EXPENSE"]),
+	description: z.string(),
+	supportItemCode: z.string(),
+	serviceDate: z.string(),
+	quantity: z.number(),
+	unit: z.enum(["HOUR", "KM", "MINUTE", "EACH"]),
+	unitPrice: z.number(),
+	total: z.number(),
+	activityId: z.string().optional(),
+	// The printed Details column, frozen so re-renders can't drift
+	// (docs/plans/017 Step 2).
+	detailsText: z.string(),
+	// The printed Unit Price column's suffix — absent for EXPENSE lines,
+	// which print no unit price (docs/plans/017 Step 6).
+	unitPriceSuffix: z.enum(["hr", "km"]).optional()
+});
+
+export const invoiceVersionContentSchema = z.object({
+	schemaVersion: z.literal(1),
+	backfilled: z.boolean().optional(),
+	header: z.object({
+		invoiceNo: z.string(),
+		displayInvoiceNo: z.string(),
+		date: z.string(),
+		participantName: z.string(),
+		participantNumber: z.string().optional(),
+		billTo: z.string().optional(),
+		// Set on versions >= 2: the previous version's display number.
+		amendsDisplayInvoiceNo: z.string().optional()
+	}),
+	provider: z.object({
+		name: z.string().optional(),
+		abn: z.string().optional(),
+		bankName: z.string().optional(),
+		bsb: z.string().optional(),
+		accountNumber: z.string().optional()
+	}),
+	lines: z.array(invoiceVersionLineSchema),
+	total: z.number()
+});
+
+export type InvoiceVersionLine = z.infer<typeof invoiceVersionLineSchema>;
+export type InvoiceVersionContent = z.infer<typeof invoiceVersionContentSchema>;

--- a/src/schema/invoice-version-schema.ts
+++ b/src/schema/invoice-version-schema.ts
@@ -8,6 +8,12 @@ import { z } from "zod";
  * breaking shape change bumps the literal and the renderer branches on it.
  * Never rewrite stored content to match a newer schema version.
  */
+// The printed Unit Price column's suffix. Single source of truth for the
+// "/hr" | "/km" concept shared by the live billing lines, the PDF renderer,
+// and the frozen snapshot (docs/plans/017 Step 6).
+export const unitPriceSuffixSchema = z.enum(["hr", "km"]);
+export type UnitPriceSuffix = z.infer<typeof unitPriceSuffixSchema>;
+
 export const invoiceVersionLineSchema = z.object({
 	kind: z.enum(["SUPPORT", "TRAVEL_TIME", "TRAVEL_KM", "ABT", "EXPENSE"]),
 	description: z.string(),
@@ -23,7 +29,7 @@ export const invoiceVersionLineSchema = z.object({
 	detailsText: z.string(),
 	// The printed Unit Price column's suffix — absent for EXPENSE lines,
 	// which print no unit price (docs/plans/017 Step 6).
-	unitPriceSuffix: z.enum(["hr", "km"]).optional()
+	unitPriceSuffix: unitPriceSuffixSchema.optional()
 });
 
 export const invoiceVersionContentSchema = z.object({

--- a/src/server/api/owned.ts
+++ b/src/server/api/owned.ts
@@ -19,7 +19,7 @@ function notFound(message?: string): never {
 }
 
 /** docs/adr/0004: locked ⇔ status !== CREATED — sent/paid invoices freeze content. */
-function amendFirst(invoiceNo: string): never {
+export function amendFirst(invoiceNo: string): never {
 	throw new TRPCError({
 		code: "CONFLICT",
 		message: `Invoice ${invoiceNo} is sent — amend it first`

--- a/src/server/api/owned.ts
+++ b/src/server/api/owned.ts
@@ -18,6 +18,14 @@ function notFound(message?: string): never {
 	throw new TRPCError({ code: "NOT_FOUND", message });
 }
 
+/** docs/adr/0004: locked ⇔ status !== CREATED — sent/paid invoices freeze content. */
+function amendFirst(invoiceNo: string): never {
+	throw new TRPCError({
+		code: "CONFLICT",
+		message: `Invoice ${invoiceNo} is sent — amend it first`
+	});
+}
+
 function ownedClient(prisma: PrismaClient, ownerId: string) {
 	const model = prisma.client;
 
@@ -74,6 +82,16 @@ function ownedInvoice(prisma: PrismaClient, ownerId: string) {
 			});
 			if (!record) notFound();
 			return record;
+		},
+		/** Throws NOT_FOUND if unowned, CONFLICT if sent/paid (docs/plans/017 Step 4). */
+		async assertUnlocked(id: string) {
+			const record = await model.findFirst({
+				where: { id, ownerId },
+				select: { id: true, invoiceNo: true, status: true }
+			});
+			if (!record) notFound();
+			if (record.status !== "CREATED") amendFirst(record.invoiceNo);
+			return record;
 		}
 	};
 }
@@ -109,6 +127,26 @@ function ownedActivity(prisma: PrismaClient, ownerId: string) {
 			});
 			if (records.length !== ids.length) notFound(message);
 			return records;
+		},
+		/**
+		 * Throws CONFLICT if any of these activities sits on a sent/paid
+		 * invoice (docs/plans/017 Step 4). A no-op for activities with no
+		 * invoice, or whose invoice is still a draft (ADR 0003 still applies
+		 * there).
+		 */
+		async assertNoneOnLockedInvoice(ids: string[]) {
+			if (ids.length === 0) return;
+
+			const locked = await model.findFirst({
+				where: {
+					id: { in: ids },
+					ownerId,
+					invoice: { status: { not: "CREATED" } }
+				},
+				select: { invoice: { select: { invoiceNo: true } } }
+			});
+
+			if (locked?.invoice) amendFirst(locked.invoice.invoiceNo);
 		}
 	};
 }

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -270,6 +270,7 @@ export const activityRouter = router({
 			}
 
 			await ctx.owned.activity.assert(input.id);
+			await ctx.owned.activity.assertNoneOnLockedInvoice([input.id]);
 
 			// Delete existing transport items and recreate
 			if (transportItems !== undefined) {
@@ -314,6 +315,7 @@ export const activityRouter = router({
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ ctx, input }) => {
 			await ctx.owned.activity.assert(input.id);
+			await ctx.owned.activity.assertNoneOnLockedInvoice([input.id]);
 
 			const activity = await ctx.prisma.activity.delete({
 				where: {

--- a/src/server/api/routers/client-router.integration.test.ts
+++ b/src/server/api/routers/client-router.integration.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+test("clients.list defaults to active-only, with an opt-in to include inactive", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const active = await caller.clients.create({
+		client: { name: "Active Client" }
+	});
+	const inactive = await caller.clients.create({
+		client: { name: "Inactive Client" }
+	});
+	await caller.clients.update({
+		id: inactive.id,
+		client: { name: inactive.name, active: false }
+	});
+
+	const defaultList = await caller.clients.list({});
+	expect(defaultList.clients.map((c) => c.id)).toEqual([active.id]);
+
+	const fullList = await caller.clients.list({ includeInactive: true });
+	expect(fullList.clients.map((c) => c.id).sort()).toEqual(
+		[active.id, inactive.id].sort()
+	);
+});
+
+test("clients.update can reactivate a deactivated client", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Some Client" }
+	});
+	await caller.clients.update({
+		id: client.id,
+		client: { name: client.name, active: false }
+	});
+
+	let byId = await caller.clients.byId({ id: client.id });
+	expect(byId.active).toBe(false);
+
+	await caller.clients.update({
+		id: client.id,
+		client: { name: client.name, active: true }
+	});
+
+	byId = await caller.clients.byId({ id: client.id });
+	expect(byId.active).toBe(true);
+});
+
+test("new clients default to active", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Fresh Client" }
+	});
+
+	expect(client.active).toBe(true);
+});

--- a/src/server/api/routers/client-router.ts
+++ b/src/server/api/routers/client-router.ts
@@ -13,6 +13,7 @@ const defaultClientSelect = {
 	number: true,
 	billTo: true,
 	invoiceNumberPrefix: true,
+	active: true,
 	invoices: {
 		select: {
 			invoiceNo: true,
@@ -23,10 +24,12 @@ const defaultClientSelect = {
 
 export const clientRouter = router({
 	list: authedProcedure
-		.input(baseListQueryInput)
+		.input(
+			baseListQueryInput.extend({ includeInactive: z.boolean().optional() })
+		)
 		.query(async ({ ctx, input }) => {
 			const limit = input.limit ?? DEFAULT_LIST_LIMIT;
-			const { cursor } = input;
+			const { cursor, includeInactive } = input;
 
 			const { items: clients, nextCursor } = await paginate({
 				limit,
@@ -49,6 +52,7 @@ export const clientRouter = router({
 								}
 							}
 						},
+						where: includeInactive ? undefined : { active: true },
 						cursor,
 						orderBy: {
 							createdAt: "desc"
@@ -219,6 +223,18 @@ export const clientRouter = router({
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ input, ctx }) => {
 			await ctx.owned.client.assert(input.id);
+
+			const versionedInvoice = await ctx.prisma.invoice.findFirst({
+				where: { clientId: input.id, versions: { some: {} } },
+				select: { id: true }
+			});
+			if (versionedInvoice) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message:
+						"Client has sent invoices and can't be deleted — deactivate instead"
+				});
+			}
 
 			const client = await ctx.prisma.client.delete({
 				where: {

--- a/src/server/api/routers/invoice-router.integration.test.ts
+++ b/src/server/api/routers/invoice-router.integration.test.ts
@@ -1,0 +1,257 @@
+import prisma from "@/server/prisma";
+import { TRPCError } from "@trpc/server";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function setupInvoiceWithActivity(
+	user: Awaited<ReturnType<typeof createTestUser>>
+) {
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Jane Citizen" }
+	});
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-1",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	return { caller, client, supportItem, activity, invoice };
+}
+
+test("send freezes v1 with correct content and locks the invoice", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	const { invoices } = await caller.invoice.send({ ids: [invoice.id] });
+
+	expect(invoices[0].status).toBe("SENT");
+	expect(invoices[0].versions).toHaveLength(1);
+	expect(invoices[0].versions![0].versionNumber).toBe(1);
+	expect(invoices[0].versions![0].displayInvoiceNo).toBe("INV-1");
+	expect(invoices[0].versions![0].total).toBeGreaterThan(0);
+
+	const versions = await prisma.invoiceVersion.findMany({
+		where: { invoiceId: invoice.id }
+	});
+	expect(versions).toHaveLength(1);
+	expect(versions[0].versionNumber).toBe(1);
+
+	const content = versions[0].content as { lines: unknown[]; total: number };
+	expect(content.lines.length).toBeGreaterThan(0);
+	expect(content.total).toBe(Number(versions[0].total));
+});
+
+test("double-send is rejected", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	await expect(caller.invoice.send({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
+
+	const versions = await prisma.invoiceVersion.findMany({
+		where: { invoiceId: invoice.id }
+	});
+	expect(versions).toHaveLength(1);
+});
+
+test("sending an invoice with no activities is rejected", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+	const client = await caller.clients.create({
+		client: { name: "No Activities" }
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-EMPTY",
+			activitiesToCreate: []
+		}
+	});
+
+	await expect(caller.invoice.send({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
+
+	const unchanged = await caller.invoice.byId({ id: invoice.id });
+	expect(unchanged.status).toBe("CREATED");
+});
+
+test("amend unlocks a SENT invoice back to CREATED", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+	const amended = await caller.invoice.amend({ id: invoice.id });
+
+	expect(amended.status).toBe("CREATED");
+	expect(amended.sentAt).toBeNull();
+
+	const byId = await caller.invoice.byId({ id: invoice.id });
+	expect(byId.versions).toHaveLength(1);
+});
+
+test("amend unlocks a PAID invoice back to CREATED, and re-sending adds v2 with the supersedes reference", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+	await caller.invoice.markPaid({ ids: [invoice.id] });
+
+	const amended = await caller.invoice.amend({ id: invoice.id });
+	expect(amended.status).toBe("CREATED");
+	expect(amended.paidAt).toBeNull();
+
+	// The paid version keeps its own paidAt even after the invoice-level
+	// field is cleared by amend (docs/plans/017 Step 3).
+	const v1 = await prisma.invoiceVersion.findFirstOrThrow({
+		where: { invoiceId: invoice.id, versionNumber: 1 }
+	});
+	expect(v1.paidAt).not.toBeNull();
+
+	const { invoices } = await caller.invoice.send({ ids: [invoice.id] });
+	expect(invoices[0].versions).toHaveLength(2);
+	const v2 = invoices[0].versions!.find((v) => v.versionNumber === 2)!;
+	expect(v2.displayInvoiceNo).toBe("INV-1a");
+
+	const v2Content = (
+		await prisma.invoiceVersion.findFirstOrThrow({
+			where: { invoiceId: invoice.id, versionNumber: 2 }
+		})
+	).content as { header: { amendsDisplayInvoiceNo?: string } };
+	expect(v2Content.header.amendsDisplayInvoiceNo).toBe("INV-1");
+});
+
+test("amend rejects a draft invoice", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await expect(caller.invoice.amend({ id: invoice.id })).rejects.toThrow(
+		TRPCError
+	);
+});
+
+test("markPaid rejects a draft invoice", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await expect(caller.invoice.markPaid({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
+});
+
+test("unmarkPaid clears paidAt on the invoice and the latest version", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+	await caller.invoice.markPaid({ ids: [invoice.id] });
+
+	const { invoices } = await caller.invoice.unmarkPaid({ ids: [invoice.id] });
+	expect(invoices[0].status).toBe("SENT");
+	expect(invoices[0].paidAt).toBeNull();
+
+	const v1 = await prisma.invoiceVersion.findFirstOrThrow({
+		where: { invoiceId: invoice.id, versionNumber: 1 }
+	});
+	expect(v1.paidAt).toBeNull();
+});
+
+test("unmarkPaid rejects a sent (not paid) invoice", async () => {
+	const user = await createTestUser();
+	const { caller, invoice } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	await expect(
+		caller.invoice.unmarkPaid({ ids: [invoice.id] })
+	).rejects.toThrow(TRPCError);
+});
+
+test("getTotalOwing sums frozen version totals, unaffected by a post-send rate edit", async () => {
+	const user = await createTestUser();
+	const { caller, invoice, supportItem } = await setupInvoiceWithActivity(user);
+
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	const owingBeforeEdit = await caller.invoice.getTotalOwing();
+	expect(owingBeforeEdit).toBeGreaterThan(0);
+
+	await prisma.supportItem.update({
+		where: { id: supportItem.id },
+		data: { weekdayRate: 999999 }
+	});
+
+	const owingAfterEdit = await caller.invoice.getTotalOwing();
+	expect(owingAfterEdit).toBe(owingBeforeEdit);
+});
+
+test("matchByPayment finds the frozen amount, unaffected by a post-send rate edit", async () => {
+	const user = await createTestUser();
+	const { caller, invoice, supportItem } = await setupInvoiceWithActivity(user);
+
+	const { invoices } = await caller.invoice.send({ ids: [invoice.id] });
+	const frozenTotal = invoices[0].versions![0].total;
+
+	await prisma.supportItem.update({
+		where: { id: supportItem.id },
+		data: { weekdayRate: 999999 }
+	});
+
+	const { invoiceIds, invoiceDetails } = await caller.invoice.matchByPayment({
+		paymentAmount: frozenTotal
+	});
+
+	expect(invoiceIds.flat(2)).toContain(invoice.id);
+	const matched = invoiceDetails.find((i) => i.id === invoice.id)!;
+	expect(matched.total).toBe(frozenTotal);
+});
+
+test("send/amend/markPaid/unmarkPaid are scoped to the caller's own invoices", async () => {
+	const userA = await createTestUser();
+	const userB = await createTestUser();
+	const { invoice } = await setupInvoiceWithActivity(userA);
+	const callerB = callerFor(userB);
+
+	await expect(callerB.invoice.send({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
+	await expect(callerB.invoice.amend({ id: invoice.id })).rejects.toThrow(
+		TRPCError
+	);
+	await expect(callerB.invoice.markPaid({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
+	await expect(
+		callerB.invoice.unmarkPaid({ ids: [invoice.id] })
+	).rejects.toThrow(TRPCError);
+});

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -11,7 +11,7 @@ import {
 	invoiceSchema,
 	totalGroupSize
 } from "@/schema/invoice-schema";
-import { ownedDb, paginate } from "@/server/api/owned";
+import { amendFirst, ownedDb, paginate } from "@/server/api/owned";
 import { authedProcedure, router } from "@/server/api/trpc";
 import {
 	Client,
@@ -54,6 +54,15 @@ const versionSelect = {
 	total: true,
 	content: true
 } satisfies Prisma.InvoiceVersionSelect;
+
+// The version rows every status transition returns to its UI caller, newest
+// first. Shared so `send`/`amend`/`markPaid`/`unmarkPaid` can't drift apart.
+const versionInclude = {
+	versions: {
+		select: versionSelect,
+		orderBy: { versionNumber: "desc" }
+	}
+} satisfies Prisma.InvoiceInclude;
 
 type VersionRow = {
 	versionNumber: number;
@@ -151,7 +160,7 @@ const generateNestedWriteForGroupActivities = (
 	)
 });
 
-type GroupWriteCtx = {
+type RouterCtx = {
 	owned: ReturnType<typeof ownedDb>;
 	prisma: PrismaClient;
 };
@@ -161,7 +170,7 @@ type GroupWriteCtx = {
  * billed (its rate would divide by 1). Both create and modify enforce this.
  */
 const assertGroupRowsHaveParticipants = async (
-	owned: GroupWriteCtx["owned"],
+	owned: RouterCtx["owned"],
 	activitiesToCreate: InvoiceSchema["activitiesToCreate"]
 ) => {
 	const soloRowSupportItemIds = [
@@ -194,7 +203,7 @@ const assertGroupRowsHaveParticipants = async (
  * `groupSize` but no sibling activities.
  */
 const createGroupMirrorActivities = async (
-	ctx: GroupWriteCtx,
+	ctx: RouterCtx,
 	inputInvoice: InvoiceSchema,
 	ownerId: string
 ) => {
@@ -245,6 +254,75 @@ const createGroupMirrorActivities = async (
 		)
 	);
 };
+
+/**
+ * Shared scaffolding for the bulk id-list transitions (`send`, `markPaid`,
+ * `unmarkPaid`): per id, assert ownership, run `work` in its own transaction,
+ * and return the parsed invoices. Each transition supplies only its inner
+ * transactional body.
+ */
+async function transitionInvoices<
+	T extends Partial<Invoice> & { versions?: VersionRow[] }
+>(
+	ctx: RouterCtx,
+	ids: string[],
+	work: (tx: Prisma.TransactionClient, id: string) => Promise<T>
+) {
+	const invoices: T[] = [];
+
+	for (const id of ids) {
+		await ctx.owned.invoice.assert(id);
+		invoices.push(await ctx.prisma.$transaction((tx) => work(tx, id)));
+	}
+
+	return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
+}
+
+/**
+ * `markPaid` / `unmarkPaid`: both re-check the source status, stamp (or clear)
+ * `paidAt` on the invoice and its latest version, and flip the status. They
+ * differ only in the required source status, the target status, the `paidAt`
+ * value, and the conflict message.
+ */
+function setPaidState(
+	ctx: RouterCtx,
+	ids: string[],
+	opts: {
+		from: InvoiceStatus;
+		to: InvoiceStatus;
+		paidAt: Date | null;
+		conflictMessage: (invoiceNo: string) => string;
+	}
+) {
+	return transitionInvoices(ctx, ids, async (tx, id) => {
+		const existing = await tx.invoice.findUniqueOrThrow({ where: { id } });
+
+		if (existing.status !== opts.from) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: opts.conflictMessage(existing.invoiceNo)
+			});
+		}
+
+		const latestVersion = await tx.invoiceVersion.findFirst({
+			where: { invoiceId: id },
+			orderBy: { versionNumber: "desc" }
+		});
+
+		if (latestVersion) {
+			await tx.invoiceVersion.update({
+				where: { id: latestVersion.id },
+				data: { paidAt: opts.paidAt }
+			});
+		}
+
+		return tx.invoice.update({
+			where: { id },
+			data: { status: opts.to, paidAt: opts.paidAt },
+			include: versionInclude
+		});
+	});
+}
 
 export const invoiceRouter = router({
 	list: authedProcedure
@@ -508,79 +586,56 @@ export const invoiceRouter = router({
 		}),
 	send: authedProcedure
 		.input(z.object({ ids: z.array(z.string()) }))
-		.mutation(async ({ ctx, input }) => {
-			const invoices = [];
+		.mutation(({ ctx, input }) =>
+			transitionInvoices(ctx, input.ids, async (tx, id) => {
+				const existing = await tx.invoice.findUniqueOrThrow({ where: { id } });
 
-			for (const id of input.ids) {
-				await ctx.owned.invoice.assert(id);
+				if (existing.status !== InvoiceStatus.CREATED) {
+					amendFirst(existing.invoiceNo);
+				}
 
-				const invoice = await ctx.prisma.$transaction(async (tx) => {
-					const existing = await tx.invoice.findUniqueOrThrow({
-						where: { id }
+				const data = await loadInvoiceForPdf(id, ctx.session.user.id, tx);
+
+				if (!data || data.invoice.activities.length === 0) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Invoice has no activities"
 					});
+				}
 
-					if (existing.status !== InvoiceStatus.CREATED) {
-						throw new TRPCError({
-							code: "CONFLICT",
-							message: `Invoice ${existing.invoiceNo} has already been sent — amend it first`
-						});
-					}
+				const previousVersion = await tx.invoiceVersion.findFirst({
+					where: { invoiceId: id },
+					orderBy: { versionNumber: "desc" }
+				});
+				const versionNumber = (previousVersion?.versionNumber ?? 0) + 1;
+				const previousDisplayInvoiceNo = previousVersion
+					? displayInvoiceNo(existing.invoiceNo, previousVersion.versionNumber)
+					: undefined;
 
-					const data = await loadInvoiceForPdf(id, ctx.session.user.id, tx);
-
-					if (!data || data.invoice.activities.length === 0) {
-						throw new TRPCError({
-							code: "BAD_REQUEST",
-							message: "Invoice has no activities"
-						});
-					}
-
-					const previousVersion = await tx.invoiceVersion.findFirst({
-						where: { invoiceId: id },
-						orderBy: { versionNumber: "desc" }
-					});
-					const versionNumber = (previousVersion?.versionNumber ?? 0) + 1;
-					const previousDisplayInvoiceNo = previousVersion
-						? displayInvoiceNo(
-								existing.invoiceNo,
-								previousVersion.versionNumber
-							)
-						: undefined;
-
-					const content = buildInvoiceVersionContent(data, {
-						versionNumber,
-						previousDisplayInvoiceNo
-					});
-
-					const sentAt = new Date();
-
-					await tx.invoiceVersion.create({
-						data: {
-							invoiceId: id,
-							versionNumber,
-							sentAt,
-							total: content.total,
-							content
-						}
-					});
-
-					return tx.invoice.update({
-						where: { id },
-						data: { status: InvoiceStatus.SENT, sentAt },
-						include: {
-							versions: {
-								select: versionSelect,
-								orderBy: { versionNumber: "desc" }
-							}
-						}
-					});
+				const content = buildInvoiceVersionContent(data, {
+					versionNumber,
+					previousDisplayInvoiceNo
 				});
 
-				invoices.push(invoice);
-			}
+				const sentAt = new Date();
 
-			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
-		}),
+				await tx.invoiceVersion.create({
+					data: {
+						invoiceId: id,
+						versionNumber,
+						sentAt,
+						total: content.total,
+						content
+					}
+				});
+
+				return tx.invoice.update({
+					where: { id },
+					data: { status: InvoiceStatus.SENT, sentAt },
+					include: versionInclude
+				});
+			})
+		),
 	amend: authedProcedure
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ ctx, input }) => {
@@ -604,116 +659,31 @@ export const invoiceRouter = router({
 					sentAt: null,
 					paidAt: null
 				},
-				include: {
-					versions: {
-						select: versionSelect,
-						orderBy: { versionNumber: "desc" }
-					}
-				}
+				include: versionInclude
 			});
 
 			return parseInvoice(invoice);
 		}),
 	markPaid: authedProcedure
 		.input(z.object({ ids: z.array(z.string()) }))
-		.mutation(async ({ ctx, input }) => {
-			const invoices = [];
-
-			for (const id of input.ids) {
-				await ctx.owned.invoice.assert(id);
-
-				const invoice = await ctx.prisma.$transaction(async (tx) => {
-					const existing = await tx.invoice.findUniqueOrThrow({
-						where: { id }
-					});
-
-					if (existing.status !== InvoiceStatus.SENT) {
-						throw new TRPCError({
-							code: "CONFLICT",
-							message: `Invoice ${existing.invoiceNo} is not sent`
-						});
-					}
-
-					const paidAt = new Date();
-
-					const latestVersion = await tx.invoiceVersion.findFirst({
-						where: { invoiceId: id },
-						orderBy: { versionNumber: "desc" }
-					});
-
-					if (latestVersion) {
-						await tx.invoiceVersion.update({
-							where: { id: latestVersion.id },
-							data: { paidAt }
-						});
-					}
-
-					return tx.invoice.update({
-						where: { id },
-						data: { status: InvoiceStatus.PAID, paidAt },
-						include: {
-							versions: {
-								select: versionSelect,
-								orderBy: { versionNumber: "desc" }
-							}
-						}
-					});
-				});
-
-				invoices.push(invoice);
-			}
-
-			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
-		}),
+		.mutation(({ ctx, input }) =>
+			setPaidState(ctx, input.ids, {
+				from: InvoiceStatus.SENT,
+				to: InvoiceStatus.PAID,
+				paidAt: new Date(),
+				conflictMessage: (invoiceNo) => `Invoice ${invoiceNo} is not sent`
+			})
+		),
 	unmarkPaid: authedProcedure
 		.input(z.object({ ids: z.array(z.string()) }))
-		.mutation(async ({ ctx, input }) => {
-			const invoices = [];
-
-			for (const id of input.ids) {
-				await ctx.owned.invoice.assert(id);
-
-				const invoice = await ctx.prisma.$transaction(async (tx) => {
-					const existing = await tx.invoice.findUniqueOrThrow({
-						where: { id }
-					});
-
-					if (existing.status !== InvoiceStatus.PAID) {
-						throw new TRPCError({
-							code: "CONFLICT",
-							message: `Invoice ${existing.invoiceNo} is not paid`
-						});
-					}
-
-					const latestVersion = await tx.invoiceVersion.findFirst({
-						where: { invoiceId: id },
-						orderBy: { versionNumber: "desc" }
-					});
-
-					if (latestVersion) {
-						await tx.invoiceVersion.update({
-							where: { id: latestVersion.id },
-							data: { paidAt: null }
-						});
-					}
-
-					return tx.invoice.update({
-						where: { id },
-						data: { status: InvoiceStatus.SENT, paidAt: null },
-						include: {
-							versions: {
-								select: versionSelect,
-								orderBy: { versionNumber: "desc" }
-							}
-						}
-					});
-				});
-
-				invoices.push(invoice);
-			}
-
-			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
-		}),
+		.mutation(({ ctx, input }) =>
+			setPaidState(ctx, input.ids, {
+				from: InvoiceStatus.PAID,
+				to: InvoiceStatus.SENT,
+				paidAt: null,
+				conflictMessage: (invoiceNo) => `Invoice ${invoiceNo} is not paid`
+			})
+		),
 	// Keys candidates on each invoice's latest version's frozen total, not a
 	// live recompute (docs/plans/017 Step 8).
 	matchByPayment: authedProcedure

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -1,5 +1,9 @@
-import { getTotalCostOfActivities } from "@/lib/activity-utils";
-import { invoiceCandidatesFromPaymentAmount } from "@/lib/invoice-utils";
+import {
+	displayInvoiceNo,
+	invoiceCandidatesFromPaymentAmount
+} from "@/lib/invoice-utils";
+import { buildInvoiceVersionContent } from "@/lib/invoice-version";
+import { loadInvoiceForPdf } from "@/lib/pdf-generation";
 import { baseListQueryInput } from "@/lib/trpc";
 import { activitySchema } from "@/schema/activity-schema";
 import {
@@ -13,7 +17,8 @@ import {
 	Client,
 	Invoice,
 	InvoiceStatus,
-	PrismaClient
+	PrismaClient,
+	type Prisma
 } from "@/generated/client";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
 import dayjs from "dayjs";
@@ -42,12 +47,52 @@ const defaultInvoiceSelect = {
 	}
 };
 
-export function parseInvoice<T extends Partial<Invoice>>(
-	invoice: T
-): Omit<T, "date"> & { date?: string } {
+const versionSelect = {
+	versionNumber: true,
+	sentAt: true,
+	paidAt: true,
+	total: true,
+	content: true
+} satisfies Prisma.InvoiceVersionSelect;
+
+type VersionRow = {
+	versionNumber: number;
+	sentAt: Date;
+	paidAt: Date | null;
+	total: Prisma.Decimal;
+	content: Prisma.JsonValue;
+};
+
+function parseVersion(invoiceNo: string, version: VersionRow) {
+	const content =
+		version.content && typeof version.content === "object"
+			? (version.content as { backfilled?: boolean })
+			: undefined;
+
 	return {
-		...invoice,
-		date: dayjs(invoice.date).format("YYYY-MM-DD")
+		versionNumber: version.versionNumber,
+		displayInvoiceNo: displayInvoiceNo(invoiceNo, version.versionNumber),
+		sentAt: version.sentAt,
+		paidAt: version.paidAt,
+		total: Number(version.total),
+		backfilled: content?.backfilled === true
+	};
+}
+
+export function parseInvoice<
+	T extends Partial<Invoice> & { versions?: VersionRow[] }
+>(invoice: T) {
+	const { versions, ...rest } = invoice;
+
+	return {
+		...rest,
+		date: dayjs(invoice.date).format("YYYY-MM-DD"),
+		...(versions && {
+			versions: versions
+				.slice()
+				.sort((a, b) => b.versionNumber - a.versionNumber)
+				.map((version) => parseVersion(invoice.invoiceNo ?? "", version))
+		})
 	};
 }
 
@@ -223,6 +268,11 @@ export const invoiceRouter = router({
 							...defaultInvoiceSelect,
 							_count: {
 								select: { activities: true }
+							},
+							versions: {
+								select: versionSelect,
+								orderBy: { versionNumber: "desc" },
+								take: 1
 							}
 						},
 						take,
@@ -255,14 +305,16 @@ export const invoiceRouter = router({
 				nextCursor
 			};
 		}),
+	// Sums the latest version's frozen total for each SENT invoice — not a
+	// live recompute — so a post-send rate/catalogue edit can't move an
+	// amount already owed (docs/plans/017 Step 8).
 	getTotalOwing: authedProcedure.query(async ({ ctx }) => {
 		const invoices = await ctx.owned.invoice.findMany({
 			select: {
-				activities: {
-					include: {
-						supportItem: true,
-						client: { select: { transitRatePerKm: true } }
-					}
+				versions: {
+					select: { total: true },
+					orderBy: { versionNumber: "desc" },
+					take: 1
 				}
 			},
 			where: {
@@ -270,21 +322,10 @@ export const invoiceRouter = router({
 			}
 		});
 
-		const user = await ctx.prisma.user.findUnique({
-			where: { id: ctx.session.user.id },
-			select: { transitRatePerKm: true }
-		});
-		const rateContext = {
-			userTransitRatePerKm: Number(user?.transitRatePerKm ?? 0.99)
-		};
-
-		const totalOwing = invoices.reduce(
-			(total, invoice) =>
-				(total += getTotalCostOfActivities(invoice.activities, rateContext)),
+		return invoices.reduce(
+			(total, invoice) => total + Number(invoice.versions[0]?.total ?? 0),
 			0
 		);
-
-		return totalOwing;
 	}),
 	byId: authedProcedure
 		.input(z.object({ id: z.string() }))
@@ -304,6 +345,10 @@ export const invoiceRouter = router({
 							id: true,
 							supportItemId: true
 						}
+					},
+					versions: {
+						select: versionSelect,
+						orderBy: { versionNumber: "desc" }
 					}
 				},
 				where: {
@@ -341,6 +386,11 @@ export const invoiceRouter = router({
 				await ctx.owned.activity.assertAll(
 					inputInvoice.activityIds,
 					"One or more activities not found"
+				);
+				// `connect` below would silently reassign an activity away from
+				// whatever invoice currently holds it (docs/plans/017 Step 4 audit).
+				await ctx.owned.activity.assertNoneOnLockedInvoice(
+					inputInvoice.activityIds
 				);
 			}
 
@@ -386,7 +436,7 @@ export const invoiceRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const { id, invoice: inputInvoice } = input;
 
-			await ctx.owned.invoice.assert(id);
+			await ctx.owned.invoice.assertUnlocked(id);
 
 			const client = await ctx.owned.client.findFirst({
 				where: { id: inputInvoice.clientId }
@@ -396,6 +446,11 @@ export const invoiceRouter = router({
 				await ctx.owned.activity.assertAll(
 					inputInvoice.activityIds,
 					"One or more activities not found"
+				);
+				// `connect` below would silently reassign an activity away from
+				// whatever invoice currently holds it (docs/plans/017 Step 4 audit).
+				await ctx.owned.activity.assertNoneOnLockedInvoice(
+					inputInvoice.activityIds
 				);
 			}
 
@@ -451,43 +506,216 @@ export const invoiceRouter = router({
 				invoice: parseInvoice(invoice)
 			};
 		}),
-	updateStatus: authedProcedure
-		.input(
-			z.object({
-				ids: z.array(z.string()),
-				status: z.nativeEnum(InvoiceStatus)
-			})
-		)
+	send: authedProcedure
+		.input(z.object({ ids: z.array(z.string()) }))
 		.mutation(async ({ ctx, input }) => {
-			const { ids, status } = input;
+			const invoices = [];
 
-			let sentAt: Date | null | undefined;
-			let paidAt: Date | null | undefined;
+			for (const id of input.ids) {
+				await ctx.owned.invoice.assert(id);
 
-			if (status === InvoiceStatus.CREATED) {
-				sentAt = null;
-				paidAt = null;
-			} else if (status === InvoiceStatus.SENT) {
-				sentAt = new Date();
-			} else {
-				paidAt = new Date();
+				const invoice = await ctx.prisma.$transaction(async (tx) => {
+					const existing = await tx.invoice.findUniqueOrThrow({
+						where: { id }
+					});
+
+					if (existing.status !== InvoiceStatus.CREATED) {
+						throw new TRPCError({
+							code: "CONFLICT",
+							message: `Invoice ${existing.invoiceNo} has already been sent — amend it first`
+						});
+					}
+
+					const data = await loadInvoiceForPdf(id, ctx.session.user.id, tx);
+
+					if (!data || data.invoice.activities.length === 0) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: "Invoice has no activities"
+						});
+					}
+
+					const previousVersion = await tx.invoiceVersion.findFirst({
+						where: { invoiceId: id },
+						orderBy: { versionNumber: "desc" }
+					});
+					const versionNumber = (previousVersion?.versionNumber ?? 0) + 1;
+					const previousDisplayInvoiceNo = previousVersion
+						? displayInvoiceNo(
+								existing.invoiceNo,
+								previousVersion.versionNumber
+							)
+						: undefined;
+
+					const content = buildInvoiceVersionContent(data, {
+						versionNumber,
+						previousDisplayInvoiceNo
+					});
+
+					const sentAt = new Date();
+
+					await tx.invoiceVersion.create({
+						data: {
+							invoiceId: id,
+							versionNumber,
+							sentAt,
+							total: content.total,
+							content
+						}
+					});
+
+					return tx.invoice.update({
+						where: { id },
+						data: { status: InvoiceStatus.SENT, sentAt },
+						include: {
+							versions: {
+								select: versionSelect,
+								orderBy: { versionNumber: "desc" }
+							}
+						}
+					});
+				});
+
+				invoices.push(invoice);
 			}
 
-			const payload = await ctx.owned.invoice.updateMany({
-				where: {
-					id: {
-						in: ids
-					}
-				},
+			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
+		}),
+	amend: authedProcedure
+		.input(z.object({ id: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			await ctx.owned.invoice.assert(input.id);
+
+			const existing = await ctx.prisma.invoice.findUniqueOrThrow({
+				where: { id: input.id }
+			});
+
+			if (existing.status === InvoiceStatus.CREATED) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: "Invoice is already a draft"
+				});
+			}
+
+			const invoice = await ctx.prisma.invoice.update({
+				where: { id: input.id },
 				data: {
-					status,
-					sentAt,
-					paidAt
+					status: InvoiceStatus.CREATED,
+					sentAt: null,
+					paidAt: null
+				},
+				include: {
+					versions: {
+						select: versionSelect,
+						orderBy: { versionNumber: "desc" }
+					}
 				}
 			});
 
-			return payload;
+			return parseInvoice(invoice);
 		}),
+	markPaid: authedProcedure
+		.input(z.object({ ids: z.array(z.string()) }))
+		.mutation(async ({ ctx, input }) => {
+			const invoices = [];
+
+			for (const id of input.ids) {
+				await ctx.owned.invoice.assert(id);
+
+				const invoice = await ctx.prisma.$transaction(async (tx) => {
+					const existing = await tx.invoice.findUniqueOrThrow({
+						where: { id }
+					});
+
+					if (existing.status !== InvoiceStatus.SENT) {
+						throw new TRPCError({
+							code: "CONFLICT",
+							message: `Invoice ${existing.invoiceNo} is not sent`
+						});
+					}
+
+					const paidAt = new Date();
+
+					const latestVersion = await tx.invoiceVersion.findFirst({
+						where: { invoiceId: id },
+						orderBy: { versionNumber: "desc" }
+					});
+
+					if (latestVersion) {
+						await tx.invoiceVersion.update({
+							where: { id: latestVersion.id },
+							data: { paidAt }
+						});
+					}
+
+					return tx.invoice.update({
+						where: { id },
+						data: { status: InvoiceStatus.PAID, paidAt },
+						include: {
+							versions: {
+								select: versionSelect,
+								orderBy: { versionNumber: "desc" }
+							}
+						}
+					});
+				});
+
+				invoices.push(invoice);
+			}
+
+			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
+		}),
+	unmarkPaid: authedProcedure
+		.input(z.object({ ids: z.array(z.string()) }))
+		.mutation(async ({ ctx, input }) => {
+			const invoices = [];
+
+			for (const id of input.ids) {
+				await ctx.owned.invoice.assert(id);
+
+				const invoice = await ctx.prisma.$transaction(async (tx) => {
+					const existing = await tx.invoice.findUniqueOrThrow({
+						where: { id }
+					});
+
+					if (existing.status !== InvoiceStatus.PAID) {
+						throw new TRPCError({
+							code: "CONFLICT",
+							message: `Invoice ${existing.invoiceNo} is not paid`
+						});
+					}
+
+					const latestVersion = await tx.invoiceVersion.findFirst({
+						where: { invoiceId: id },
+						orderBy: { versionNumber: "desc" }
+					});
+
+					if (latestVersion) {
+						await tx.invoiceVersion.update({
+							where: { id: latestVersion.id },
+							data: { paidAt: null }
+						});
+					}
+
+					return tx.invoice.update({
+						where: { id },
+						data: { status: InvoiceStatus.SENT, paidAt: null },
+						include: {
+							versions: {
+								select: versionSelect,
+								orderBy: { versionNumber: "desc" }
+							}
+						}
+					});
+				});
+
+				invoices.push(invoice);
+			}
+
+			return { invoices: invoices.map((invoice) => parseInvoice(invoice)) };
+		}),
+	// Keys candidates on each invoice's latest version's frozen total, not a
+	// live recompute (docs/plans/017 Step 8).
 	matchByPayment: authedProcedure
 		.input(z.object({ paymentAmount: z.number() }))
 		.query(async ({ ctx, input }) => {
@@ -495,12 +723,7 @@ export const invoiceRouter = router({
 
 			const invoices = await ctx.owned.invoice.findMany({
 				where: {
-					status: "SENT",
-					activities: {
-						some: {
-							id: {}
-						}
-					}
+					status: "SENT"
 				},
 				select: {
 					id: true,
@@ -511,11 +734,10 @@ export const invoiceRouter = router({
 							name: true
 						}
 					},
-					activities: {
-						include: {
-							supportItem: true,
-							client: { select: { transitRatePerKm: true } }
-						}
+					versions: {
+						select: { total: true },
+						orderBy: { versionNumber: "desc" },
+						take: 1
 					}
 				}
 			});
@@ -527,18 +749,10 @@ export const invoiceRouter = router({
 				};
 			}
 
-			const user = await ctx.prisma.user.findUnique({
-				where: { id: ctx.session.user.id },
-				select: { transitRatePerKm: true }
-			});
-			const rateContext = {
-				userTransitRatePerKm: Number(user?.transitRatePerKm ?? 0.99)
-			};
-
 			// Convert array of invoices to map of <total, invoiceId>
 			const totals = new Map<number, string | string[]>();
 			for (const invoice of invoices) {
-				const total = getTotalCostOfActivities(invoice.activities, rateContext);
+				const total = Number(invoice.versions[0]?.total ?? 0);
 
 				if (totals.has(total)) {
 					const val = totals.get(total) as string | string[];
@@ -558,9 +772,15 @@ export const invoiceRouter = router({
 				totals
 			);
 
-			const invoiceDetails = invoices.filter((invoice) =>
-				invoiceIds.flat(2).includes(invoice.id)
-			);
+			const invoiceDetails = invoices
+				.filter((invoice) => invoiceIds.flat(2).includes(invoice.id))
+				.map((invoice) => ({
+					id: invoice.id,
+					invoiceNo: invoice.invoiceNo,
+					date: invoice.date,
+					client: invoice.client,
+					total: Number(invoice.versions[0]?.total ?? 0)
+				}));
 
 			return {
 				invoiceIds,
@@ -571,6 +791,16 @@ export const invoiceRouter = router({
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ ctx, input }) => {
 			await ctx.owned.invoice.assert(input.id);
+
+			const versionCount = await ctx.prisma.invoiceVersion.count({
+				where: { invoiceId: input.id }
+			});
+			if (versionCount > 0) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: "Invoice has been sent and can't be deleted"
+				});
+			}
 
 			const invoice = await ctx.prisma.invoice.delete({
 				where: {

--- a/src/server/api/routers/pdf-router.ts
+++ b/src/server/api/routers/pdf-router.ts
@@ -8,13 +8,16 @@ export const pdfRouter = router({
 		.input(
 			z.object({
 				invoiceId: z.string(),
-				returnBase64: z.boolean().nullish()
+				returnBase64: z.boolean().nullish(),
+				versionNumber: z.number().int().positive().nullish()
 			})
 		)
 		.query(async ({ input, ctx }) => {
-			const { invoiceId, returnBase64 } = input;
+			const { invoiceId, returnBase64, versionNumber } = input;
 
-			const { pdfString } = await generatePDF(invoiceId, ctx.session.user.id);
+			const { pdfString } = await generatePDF(invoiceId, ctx.session.user.id, {
+				versionNumber: versionNumber ?? undefined
+			});
 
 			if (!pdfString) {
 				throw new TRPCError({ code: "NOT_FOUND" });

--- a/src/server/api/routers/support-item-router.ts
+++ b/src/server/api/routers/support-item-router.ts
@@ -1,7 +1,7 @@
 import { baseListQueryInput } from "@/lib/trpc";
 import { supportItemRatesSchema } from "@/schema/support-item-rates-schema";
 import { supportItemSchema } from "@/schema/support-item-schema";
-import { paginate } from "@/server/api/owned";
+import { amendFirst, paginate } from "@/server/api/owned";
 import { authedProcedure, router } from "@/server/api/trpc";
 import { Prisma } from "@/generated/client";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
@@ -249,10 +249,7 @@ export const supportItemRouter = router({
 				select: { invoice: { select: { invoiceNo: true } } }
 			});
 			if (lockedActivity?.invoice) {
-				throw new TRPCError({
-					code: "CONFLICT",
-					message: `Invoice ${lockedActivity.invoice.invoiceNo} is sent — amend it first`
-				});
+				amendFirst(lockedActivity.invoice.invoiceNo);
 			}
 
 			const supportItem = await ctx.prisma.supportItem.delete({

--- a/src/server/api/routers/support-item-router.ts
+++ b/src/server/api/routers/support-item-router.ts
@@ -238,6 +238,23 @@ export const supportItemRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			await ctx.owned.supportItem.assert(input.id);
 
+			// The schema cascade-deletes Activity rows on SupportItem delete —
+			// without this guard that would silently eat a sent invoice's
+			// frozen-in-spirit activities (docs/plans/017 Step 4).
+			const lockedActivity = await ctx.prisma.activity.findFirst({
+				where: {
+					supportItemId: input.id,
+					invoice: { status: { not: "CREATED" } }
+				},
+				select: { invoice: { select: { invoiceNo: true } } }
+			});
+			if (lockedActivity?.invoice) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: `Invoice ${lockedActivity.invoice.invoiceNo} is sent — amend it first`
+				});
+			}
+
 			const supportItem = await ctx.prisma.supportItem.delete({
 				where: {
 					id: input.id

--- a/src/server/api/routers/trip-router.ts
+++ b/src/server/api/routers/trip-router.ts
@@ -86,6 +86,8 @@ export const tripRouter = router({
 				});
 			}
 
+			await ctx.owned.activity.assertNoneOnLockedInvoice(input.activityIds);
+
 			const updates = tripTransitUpdates(activities, input.interClientLegs);
 
 			return ctx.prisma.$transaction(async (tx) => {
@@ -159,6 +161,11 @@ export const tripRouter = router({
 				});
 			}
 
+			await ctx.owned.activity.assertNoneOnLockedInvoice([
+				...trip.activities.map((a) => a.id),
+				activity.id
+			]);
+
 			const allActivities = [...trip.activities, activity];
 			const allLegs = [...trip.interClientLegs, ...input.interClientLegs];
 			const updates = tripTransitUpdates(allActivities, allLegs);
@@ -225,6 +232,10 @@ export const tripRouter = router({
 					message: "Activity not in trip"
 				});
 			}
+
+			await ctx.owned.activity.assertNoneOnLockedInvoice(
+				trip.activities.map((a) => a.id)
+			);
 
 			const remainingActivities = trip.activities.filter(
 				(a) => a.id !== input.activityId
@@ -330,6 +341,10 @@ export const tripRouter = router({
 				throw new TRPCError({ code: "NOT_FOUND" });
 			}
 
+			await ctx.owned.activity.assertNoneOnLockedInvoice(
+				trip.activities.map((a) => a.id)
+			);
+
 			const updates = tripTransitUpdates(
 				trip.activities,
 				input.interClientLegs
@@ -378,6 +393,10 @@ export const tripRouter = router({
 			if (!trip) {
 				throw new TRPCError({ code: "NOT_FOUND" });
 			}
+
+			await ctx.owned.activity.assertNoneOnLockedInvoice(
+				trip.activities.map((a) => a.id)
+			);
 
 			const updates = standaloneTransitUpdates(trip.activities);
 

--- a/src/server/api/test/invoice-locks.integration.test.ts
+++ b/src/server/api/test/invoice-locks.integration.test.ts
@@ -1,0 +1,321 @@
+import prisma from "@/server/prisma";
+import { TRPCError } from "@trpc/server";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "./harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function setupSentInvoice() {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({
+		client: { name: "Jane Citizen" }
+	});
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activityA = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const activityB = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-02"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-1",
+			activityIds: [activityA.id, activityB.id],
+			activitiesToCreate: []
+		}
+	});
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	return { user, caller, client, supportItem, activityA, activityB, invoice };
+}
+
+test("invoice.modify rejects a locked invoice", async () => {
+	const { caller, invoice } = await setupSentInvoice();
+
+	await expect(
+		caller.invoice.modify({
+			id: invoice.id,
+			invoice: {
+				clientId: invoice.clientId,
+				invoiceNo: "INV-1-RENAMED",
+				activitiesToCreate: []
+			}
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("invoice.create rejects connecting an activity that belongs to a locked invoice", async () => {
+	const { caller, client, activityA } = await setupSentInvoice();
+
+	await expect(
+		caller.invoice.create({
+			invoice: {
+				clientId: client.id,
+				invoiceNo: "INV-STEAL",
+				activityIds: [activityA.id],
+				activitiesToCreate: []
+			}
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("invoice.modify rejects connecting an activity that belongs to another locked invoice", async () => {
+	const { caller, client, activityA } = await setupSentInvoice();
+
+	const draftInvoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-DRAFT-2",
+			activitiesToCreate: []
+		}
+	});
+
+	await expect(
+		caller.invoice.modify({
+			id: draftInvoice.id,
+			invoice: {
+				clientId: client.id,
+				invoiceNo: "INV-DRAFT-2",
+				activityIds: [activityA.id],
+				activitiesToCreate: []
+			}
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("invoice.delete rejects an invoice with a version", async () => {
+	const { caller, invoice } = await setupSentInvoice();
+
+	await expect(caller.invoice.delete({ id: invoice.id })).rejects.toThrow(
+		TRPCError
+	);
+
+	const stillExists = await prisma.invoice.findUnique({
+		where: { id: invoice.id }
+	});
+	expect(stillExists).not.toBeNull();
+});
+
+test("activity.modify rejects an activity on a locked invoice", async () => {
+	const { caller, activityA } = await setupSentInvoice();
+
+	await expect(
+		caller.activity.modify({
+			id: activityA.id,
+			activity: {
+				clientId: activityA.clientId!,
+				supportItemId: activityA.supportItemId,
+				date: activityA.date,
+				startTime: "09:00",
+				endTime: "11:00",
+				itemDistance: 0
+			}
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("activity.delete rejects an activity on a locked invoice", async () => {
+	const { caller, activityA } = await setupSentInvoice();
+
+	await expect(caller.activity.delete({ id: activityA.id })).rejects.toThrow(
+		TRPCError
+	);
+});
+
+test("activity.modify still works on a draft invoice's activity", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+	const client = await caller.clients.create({ client: { name: "Draft" } });
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-DRAFT",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	const { activity: modified } = await caller.activity.modify({
+		id: activity.id,
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "11:00",
+			itemDistance: 0
+		}
+	});
+	expect(modified.id).toBe(activity.id);
+});
+
+test("trip.create rejects when an activity is on a locked invoice", async () => {
+	const { caller, activityA, activityB } = await setupSentInvoice();
+
+	await expect(
+		caller.trip.create({
+			date: new Date("2024-01-01"),
+			activityIds: [activityA.id, activityB.id],
+			interClientLegs: []
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("trip.addActivity rejects when the incoming activity is on a locked invoice", async () => {
+	const { caller, client, supportItem, activityA } = await setupSentInvoice();
+
+	const draftActivity1 = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-02-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const draftActivity2 = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-02-01"),
+			startTime: "10:00",
+			endTime: "11:00",
+			itemDistance: 0
+		}
+	});
+	const trip = await caller.trip.create({
+		date: new Date("2024-02-01"),
+		activityIds: [draftActivity1.id, draftActivity2.id],
+		interClientLegs: []
+	});
+
+	await expect(
+		caller.trip.addActivity({
+			tripId: trip!.id,
+			activityId: activityA.id,
+			interClientLegs: []
+		})
+	).rejects.toThrow(TRPCError);
+});
+
+test("trip.removeActivity/update/delete reject once the trip's activities are on a locked invoice", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+	const client = await caller.clients.create({ client: { name: "Trip" } });
+	const supportItem = await prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01",
+			weekdayRate: 100,
+			ownerId: user.id
+		}
+	});
+	const activityA = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const activityB = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "10:00",
+			endTime: "11:00",
+			itemDistance: 0
+		}
+	});
+	const trip = await caller.trip.create({
+		date: new Date("2024-01-01"),
+		activityIds: [activityA.id, activityB.id],
+		interClientLegs: []
+	});
+
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-TRIP",
+			activityIds: [activityA.id, activityB.id],
+			activitiesToCreate: []
+		}
+	});
+	await caller.invoice.send({ ids: [invoice.id] });
+
+	await expect(
+		caller.trip.removeActivity({ tripId: trip!.id, activityId: activityA.id })
+	).rejects.toThrow(TRPCError);
+
+	await expect(
+		caller.trip.update({ tripId: trip!.id, interClientLegs: [] })
+	).rejects.toThrow(TRPCError);
+
+	await expect(caller.trip.delete({ tripId: trip!.id })).rejects.toThrow(
+		TRPCError
+	);
+});
+
+test("support-item.delete rejects when an activity on a locked invoice uses it", async () => {
+	const { caller, supportItem } = await setupSentInvoice();
+
+	await expect(
+		caller.supportItem.delete({ id: supportItem.id })
+	).rejects.toThrow(TRPCError);
+});
+
+test("clients.delete rejects when the client has a sent invoice", async () => {
+	const { caller, client } = await setupSentInvoice();
+
+	await expect(caller.clients.delete({ id: client.id })).rejects.toThrow(
+		TRPCError
+	);
+});

--- a/src/server/api/test/ownership.integration.test.ts
+++ b/src/server/api/test/ownership.integration.test.ts
@@ -25,7 +25,7 @@ test("two users see only their own clients", async () => {
 	expect((await callerB.clients.list({})).clients).toHaveLength(0);
 });
 
-test("invoice.updateStatus scoped to caller's own invoices as a no-op, not a NOT_FOUND", async () => {
+test("invoice.send rejects a cross-tenant invoice, leaving it unaffected", async () => {
 	const userA = await createTestUser();
 	const userB = await createTestUser();
 	const callerA = callerFor(userA);
@@ -42,15 +42,9 @@ test("invoice.updateStatus scoped to caller's own invoices as a no-op, not a NOT
 		}
 	});
 
-	// NOTE: unlike the other single-record mutations in this suite,
-	// updateStatus uses `updateMany` scoped by ownerId rather than a
-	// findFirst-then-update, so a cross-tenant call silently matches zero
-	// rows instead of throwing NOT_FOUND. A's data is unaffected either way.
-	const payload = await callerB.invoice.updateStatus({
-		ids: [invoice.id],
-		status: "SENT"
-	});
-	expect(payload.count).toBe(0);
+	await expect(callerB.invoice.send({ ids: [invoice.id] })).rejects.toThrow(
+		TRPCError
+	);
 
 	const unchanged = await callerA.invoice.byId({ id: invoice.id });
 	expect(unchanged.status).toBe("CREATED");
@@ -157,7 +151,7 @@ test("invoice.getTotalOwing excludes another owner's SENT invoices", async () =>
 			activitiesToCreate: []
 		}
 	});
-	await callerA.invoice.updateStatus({ ids: [invoice.id], status: "SENT" });
+	await callerA.invoice.send({ ids: [invoice.id] });
 
 	expect(await callerA.invoice.getTotalOwing()).toBeGreaterThan(0);
 	expect(await callerB.invoice.getTotalOwing()).toBe(0);

--- a/vitest.integration.config.mts
+++ b/vitest.integration.config.mts
@@ -5,7 +5,10 @@ export default defineConfig({
 	plugins: [tsconfigPaths()],
 	test: {
 		environment: "node",
-		include: ["./src/**/*.integration.test.ts"],
+		include: [
+			"./src/**/*.integration.test.ts",
+			"./prisma/**/*.integration.test.ts"
+		],
 		fileParallelism: false,
 		globalSetup: ["./src/server/api/test/global-setup.ts"],
 		watch: false


### PR DESCRIPTION
## Summary
- Sending an invoice now freezes an immutable `InvoiceVersion` (resolved lines, totals, header, provider details as jsonb) instead of the PDF being recomputed from live data forever.
- Clean PDFs render only from a frozen version; any live/draft render carries a DRAFT watermark. Amending unlocks a sent/paid invoice back to draft; re-sending freezes the next version (INV-001 → INV-001a → ...) with a "supersedes" line.
- Sent/paid invoices (and their activities/trips/support items) are locked against mutation until amended; deleting a client or invoice with any version is blocked.
- `getTotalOwing` / `matchByPayment` read frozen version totals instead of recomputing live, so a later rate change can't move an amount already owed.
- One-off idempotent backfill script for pre-existing SENT/PAID invoices with no version.
- UI: draft download offers "Download draft" vs "Send & download"; invoice page shows version history with per-version download; Amend requires confirmation; the edit route redirects away from locked invoices.

Implements `docs/plans/017-invoice-versioning.md` in full (steps 1-10), design authority `docs/adr/0004-invoice-versions-freeze-rendered-output.md`.

## Code review follow-up

Addressed the Standards axis findings from `/code-review` (Spec axis had none):
- Deduped the triplicated status-transition scaffolding in `invoice-router.ts` into shared `transitionInvoices` / `setPaidState` helpers, plus a single `versionInclude` const (was repeated across `send`/`amend`/`markPaid`/`unmarkPaid`).
- Single-sourced the "amend it first" conflict message: `amendFirst` is now exported from `owned.ts` and called by `invoice.send` and `supportItem.delete` instead of inlined copies.
- Made the zod enum the single source of truth for the `"hr" | "km"` unit-price suffix (`unitPriceSuffixSchema` + inferred `UnitPriceSuffix`), consumed by `billing-lines.ts` and `pdf-generation.ts`.
- Hoisted the doubly-computed `lineUnitPriceSuffix` call in `invoice-version.ts`.

## Rebased onto plan 016

This branch has been rebased onto current `main`, which includes plan 016 (group activities with up to 10 participants) — the change that rewrote `src/lib/billing-lines.ts` (rate apportionment), `src/server/api/routers/invoice-router.ts`, and `src/server/api/routers/activity-router.ts`. The snapshot schema is aligned with plan 016's live `BillableLine` shape, and the two rate-computation paths are reconciled. GitHub reports this PR as mergeable.

## Test plan
- [x] `pnpm exec vitest run` (unit, 107 tests) — pass
- [x] `pnpm exec vitest run --config vitest.integration.config.mts` (integration, 54 tests) — pass, including a byte-stability test that freezes a version, mutates every upstream input directly in the DB, and re-renders identically
- [x] `pnpm exec playwright test --project=e2e --workers=1` (18 tests incl. new Step 7 journey: create → download draft (watermarked) → send & download → amend (confirm) → edit activity → re-send → v1a with supersedes line → both versions downloadable → list shows one row) — pass
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check` — all clean
- [x] Rebased onto current `main` and reconciled the billing-lines/invoice-router/activity-router paths against plan 016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
