### PR TITLE
test: integration coverage for user-router + custom rates

### DIFF
--- a/src/server/api/routers/support-item-router.integration.test.ts
+++ b/src/server/api/routers/support-item-router.integration.test.ts
@@ -1,0 +1,145 @@
+import prisma from "@/server/prisma";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function createSupportItem(ownerId: string, weekdayRate = 100) {
+	return prisma.supportItem.create({
+		data: {
+			description: "Standard Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate,
+			ownerId
+		}
+	});
+}
+
+test("addCustomRates then getCustomRatesForClient returns the rate with the support item description", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const supportItem = await createSupportItem(user.id);
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+
+	await caller.supportItem.addCustomRates({
+		supportItemRates: {
+			supportItemId: supportItem.id,
+			clientId: client.id,
+			weekdayRate: 200
+		}
+	});
+
+	const rates = await caller.supportItem.getCustomRatesForClient({
+		id: client.id
+	});
+	expect(rates).toHaveLength(1);
+	expect(rates[0].supportItemId).toBe(supportItem.id);
+	expect(Number(rates[0].weekdayRate)).toBe(200);
+	expect(rates[0].supportItem).toEqual({
+		description: supportItem.description
+	});
+});
+
+test("updateCustomRate with a partial payload updates only the provided fields", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const supportItem = await createSupportItem(user.id);
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+
+	const rate = await caller.supportItem.addCustomRates({
+		supportItemRates: {
+			supportItemId: supportItem.id,
+			clientId: client.id,
+			weekdayRate: 200,
+			saturdayRate: 250
+		}
+	});
+
+	await caller.supportItem.updateCustomRate({
+		id: rate.id,
+		supportItemRates: { weekdayRate: 300 }
+	});
+
+	const updated = await prisma.supportItemRates.findUniqueOrThrow({
+		where: { id: rate.id }
+	});
+	expect(Number(updated.weekdayRate)).toBe(300);
+	// The untouched field must survive - pins the `.partial()` semantics so a
+	// regression that drops omitted fields on update is caught.
+	expect(Number(updated.saturdayRate)).toBe(250);
+});
+
+test("updateCustomRate rejects another user's rate row with NOT_FOUND", async () => {
+	const userA = await createTestUser();
+	const userB = await createTestUser();
+	const callerA = callerFor(userA);
+	const callerB = callerFor(userB);
+
+	const supportItem = await createSupportItem(userA.id);
+	const client = await callerA.clients.create({ client: { name: "Jane" } });
+	const rate = await callerA.supportItem.addCustomRates({
+		supportItemRates: {
+			supportItemId: supportItem.id,
+			clientId: client.id,
+			weekdayRate: 200
+		}
+	});
+
+	await expect(
+		callerB.supportItem.updateCustomRate({
+			id: rate.id,
+			supportItemRates: { weekdayRate: 999 }
+		})
+	).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+	// A's rate is unchanged.
+	const untouched = await prisma.supportItemRates.findUniqueOrThrow({
+		where: { id: rate.id }
+	});
+	expect(Number(untouched.weekdayRate)).toBe(200);
+});
+
+test("a client's custom rate drives the invoice total over the support item default", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	// Default rate 100/hr; custom rate for this client 200/hr.
+	const supportItem = await createSupportItem(user.id, 100);
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	await caller.supportItem.addCustomRates({
+		supportItemRates: {
+			supportItemId: supportItem.id,
+			clientId: client.id,
+			weekdayRate: 200
+		}
+	});
+
+	// One-hour weekday activity (2024-01-01 is a Monday).
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const invoice = await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-1",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	const { invoices } = await caller.invoice.send({ ids: [invoice.id] });
+
+	// 1 hour × custom 200/hr = 200, not the item's default 100.
+	expect(invoices[0].versions![0].total).toBe(200);
+});

--- a/src/server/api/routers/user-router.integration.test.ts
+++ b/src/server/api/routers/user-router.integration.test.ts
@@ -1,0 +1,224 @@
+import prisma from "@/server/prisma";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+const PROFILE = {
+	name: "Provider Name",
+	abn: 12_345_678_901,
+	bankName: "Test Bank",
+	bankNumber: 12_345_678,
+	bsb: 123_456
+};
+
+function createSupportItem(ownerId: string, description = "Support") {
+	return prisma.supportItem.create({
+		data: {
+			description,
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId
+		}
+	});
+}
+
+test("update then fetch round-trips the profile and bank fields", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	await caller.user.update({ user: PROFILE });
+
+	const fetched = await caller.user.fetch();
+	expect(fetched.name).toBe(PROFILE.name);
+	expect(Number(fetched.abn)).toBe(PROFILE.abn);
+	expect(fetched.bankName).toBe(PROFILE.bankName);
+	expect(Number(fetched.bankNumber)).toBe(PROFILE.bankNumber);
+	expect(fetched.bsb).toBe(PROFILE.bsb);
+});
+
+test("getBankDetails returns exactly the payment fields and never another user's", async () => {
+	const userA = await createTestUser();
+	const userB = await createTestUser();
+	const callerA = callerFor(userA);
+	const callerB = callerFor(userB);
+
+	await callerA.user.update({ user: PROFILE });
+
+	const details = await callerA.user.getBankDetails();
+	expect(Object.keys(details).sort()).toEqual([
+		"abn",
+		"bankName",
+		"bankNumber",
+		"bsb",
+		"name"
+	]);
+	expect(details.name).toBe(PROFILE.name);
+	expect(Number(details.abn)).toBe(PROFILE.abn);
+	expect(Number(details.bankNumber)).toBe(PROFILE.bankNumber);
+	expect(details.bankName).toBe(PROFILE.bankName);
+	expect(details.bsb).toBe(PROFILE.bsb);
+
+	// User B never set any details, and A's details must not leak across.
+	const detailsB = await callerB.user.getBankDetails();
+	expect(detailsB).toEqual({
+		name: userB.name,
+		abn: null,
+		bankNumber: null,
+		bankName: null,
+		bsb: null
+	});
+});
+
+test("reset clears all owned data and nulls the profile, leaving other users untouched", async () => {
+	const owner = await createTestUser();
+	const caller = callerFor(owner);
+	await caller.user.update({ user: PROFILE });
+
+	const other = await createTestUser();
+	const otherCaller = callerFor(other);
+
+	const supportItem = await createSupportItem(owner.id);
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const activity = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	// An unsent (CREATED) invoice - deletable, so it actually exercises the
+	// cascade rather than leaving the Invoice assertion vacuous.
+	await caller.invoice.create({
+		invoice: {
+			clientId: client.id,
+			invoiceNo: "INV-1",
+			activityIds: [activity.id],
+			activitiesToCreate: []
+		}
+	});
+
+	// Another user's data, to prove reset is owner-scoped.
+	const otherSupportItem = await createSupportItem(other.id, "Other Support");
+	const otherClient = await otherCaller.clients.create({
+		client: { name: "Other Client" }
+	});
+	await otherCaller.activity.add({
+		activity: {
+			clientId: otherClient.id,
+			supportItemId: otherSupportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+
+	await caller.user.reset();
+
+	expect(await prisma.client.count({ where: { ownerId: owner.id } })).toBe(0);
+	expect(await prisma.invoice.count({ where: { ownerId: owner.id } })).toBe(0);
+	expect(await prisma.activity.count({ where: { ownerId: owner.id } })).toBe(0);
+	expect(await prisma.supportItem.count({ where: { ownerId: owner.id } })).toBe(
+		0
+	);
+
+	const nulled = await prisma.user.findUniqueOrThrow({
+		where: { id: owner.id }
+	});
+	expect(nulled.abn).toBeNull();
+	expect(nulled.name).toBeNull();
+	expect(nulled.bankName).toBeNull();
+	expect(nulled.bankNumber).toBeNull();
+	expect(nulled.bsb).toBeNull();
+
+	// The other user is untouched.
+	expect(await prisma.client.count({ where: { ownerId: other.id } })).toBe(1);
+	expect(await prisma.activity.count({ where: { ownerId: other.id } })).toBe(1);
+	expect(await prisma.supportItem.count({ where: { ownerId: other.id } })).toBe(
+		1
+	);
+});
+
+// Characterization (see issue #408): a sent invoice makes reset's first
+// `client.deleteMany` cascade into Invoice and hit the ADR-0004
+// `InvoiceVersion` onDelete: Restrict. That single Postgres DELETE statement
+// rolls back whole, so nothing is deleted - not even the unrelated clean
+// client - and the profile-nulling never runs. It's a safe atomic no-op, but
+// it leaks a raw Prisma FK error to the caller (follow-up: return a clear
+// TRPCError instead).
+test("reset atomically no-ops when a sent invoice exists (fails on the first deleteMany, nothing is deleted)", async () => {
+	const owner = await createTestUser();
+	const caller = callerFor(owner);
+	await caller.user.update({ user: PROFILE });
+
+	// Client 1: has a sent invoice (the reset blocker).
+	const sentSupportItem = await createSupportItem(owner.id, "Sent Support");
+	const sentClient = await caller.clients.create({ client: { name: "Sent" } });
+	const sentActivity = await caller.activity.add({
+		activity: {
+			clientId: sentClient.id,
+			supportItemId: sentSupportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+	const sentInvoice = await caller.invoice.create({
+		invoice: {
+			clientId: sentClient.id,
+			invoiceNo: "INV-1",
+			activityIds: [sentActivity.id],
+			activitiesToCreate: []
+		}
+	});
+	await caller.invoice.send({ ids: [sentInvoice.id] });
+
+	// Client 2: entirely clean, with its own support item and activity - its
+	// survival proves all-or-nothing.
+	const cleanSupportItem = await createSupportItem(owner.id, "Clean Support");
+	const cleanClient = await caller.clients.create({
+		client: { name: "Clean" }
+	});
+	const cleanActivity = await caller.activity.add({
+		activity: {
+			clientId: cleanClient.id,
+			supportItemId: cleanSupportItem.id,
+			date: new Date("2024-01-02"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0
+		}
+	});
+
+	await expect(caller.user.reset()).rejects.toThrow();
+
+	// Nothing deleted.
+	expect(await prisma.client.count({ where: { ownerId: owner.id } })).toBe(2);
+	expect(
+		await prisma.invoice.findUnique({ where: { id: sentInvoice.id } })
+	).not.toBeNull();
+	expect(await prisma.activity.count({ where: { ownerId: owner.id } })).toBe(2);
+	expect(
+		await prisma.activity.findUnique({ where: { id: cleanActivity.id } })
+	).not.toBeNull();
+	expect(await prisma.supportItem.count({ where: { ownerId: owner.id } })).toBe(
+		2
+	);
+
+	// Profile fields all unchanged (the nulling never ran).
+	const unchanged = await prisma.user.findUniqueOrThrow({
+		where: { id: owner.id }
+	});
+	expect(Number(unchanged.abn)).toBe(PROFILE.abn);
+	expect(unchanged.name).toBe(PROFILE.name);
+	expect(unchanged.bankName).toBe(PROFILE.bankName);
+	expect(Number(unchanged.bankNumber)).toBe(PROFILE.bankNumber);
+	expect(unchanged.bsb).toBe(PROFILE.bsb);
+});


### PR DESCRIPTION
Closes #408.

## What

Adds integration coverage for two money-adjacent surfaces that had none. **Tests only — no production code changed.**

### `user-router.integration.test.ts`
- `update`→`fetch` round-trip of profile + bank fields
- `getBankDetails` returns exactly `{ name, abn, bankNumber, bankName, bsb }` and never another user's
- `reset` clean case: all owned tables emptied, profile nulled, other user untouched (includes an unsent invoice so the Invoice assertion isn't vacuous)
- `reset` atomic no-op characterization: with a sent invoice it throws and deletes nothing — a second clean client + its own support item prove all-or-nothing; all five profile fields asserted unchanged

### `support-item-router.integration.test.ts`
- `addCustomRates`→`getCustomRatesForClient` round-trip with the description include
- `updateCustomRate` partial payload pins `.partial()` semantics (untouched `saturdayRate` survives)
- ownership: user B updating user A's rate → `NOT_FOUND`, A's row unchanged
- end-to-end: a client's custom rate (200/hr) drives the sent invoice total over the item default (100/hr)

## Verification
- `pnpm type-check` clean
- Full integration suite 75/75 pass
- `pnpm lint` 0 errors

## Follow-up
Filed #445 — `user.reset` leaks a raw Prisma FK error when a sent invoice exists (UX-only; reset is already atomic, no transaction wrapping needed), per the issue's Notes.