### PR TITLE
fix: reject out-of-range and malformed times in validateTimeRange, add form-logic unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"@auth/prisma-adapter": "2.11.2",
 		"@base-ui/react": "1.6.0",
+		"@date-fns/tz": "1.5.0",
 		"@headlessui/react": "2.2.10",
 		"@hookform/resolvers": "4.1.3",
 		"@prisma/adapter-pg": "7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,10 @@ importers:
         version: 2.11.2(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(typescript@5.9.3))(nodemailer@9.0.1)
       '@base-ui/react':
         specifier: 1.6.0
-        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@date-fns/tz':
+        specifier: 1.5.0
+        version: 1.5.0
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -542,8 +545,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@date-fns/tz@1.4.1':
-    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -5956,7 +5959,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@base-ui/react@1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5966,7 +5969,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
-      '@date-fns/tz': 1.4.1
+      '@date-fns/tz': 1.5.0
       '@types/react': 19.2.17
       date-fns: 4.1.0
 
@@ -6129,7 +6132,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@date-fns/tz@1.4.1': {}
+  '@date-fns/tz@1.5.0': {}
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
@@ -10562,7 +10565,7 @@ snapshots:
 
   react-day-picker@9.13.2(react@19.2.7):
     dependencies:
-      '@date-fns/tz': 1.4.1
+      '@date-fns/tz': 1.5.0
       date-fns: 4.1.0
       date-fns-jalali: 4.1.0-0
       react: 19.2.7

--- a/src/components/forms/time-range-input.test.ts
+++ b/src/components/forms/time-range-input.test.ts
@@ -1,0 +1,54 @@
+import { validateTimeRange } from "@/components/forms/time-range-input";
+import { expect, test } from "vitest";
+
+test("a start-before-end range is valid", () => {
+	expect(
+		validateTimeRange({ startTime: "09:30", endTime: "13:50" })
+	).toBeNull();
+});
+
+test("an end before the start is rejected", () => {
+	expect(validateTimeRange({ startTime: "13:50", endTime: "09:30" })).toBe(
+		"End time must be after start time"
+	);
+});
+
+test("equal start and end times are rejected", () => {
+	expect(validateTimeRange({ startTime: "09:30", endTime: "09:30" })).toBe(
+		"End time must be after start time"
+	);
+});
+
+test("undefined value is required", () => {
+	expect(validateTimeRange(undefined)).toBe("Time range is required");
+});
+
+test("a missing start time is required", () => {
+	expect(validateTimeRange({ startTime: "", endTime: "13:50" })).toBe(
+		"Time range is required"
+	);
+});
+
+test("a missing end time is required", () => {
+	expect(validateTimeRange({ startTime: "09:30", endTime: "" })).toBe(
+		"Time range is required"
+	);
+});
+
+test("out-of-range hours are rejected", () => {
+	expect(validateTimeRange({ startTime: "09:30", endTime: "25:00" })).toBe(
+		"Invalid time"
+	);
+});
+
+test("out-of-range minutes are rejected", () => {
+	expect(validateTimeRange({ startTime: "09:60", endTime: "13:50" })).toBe(
+		"Invalid time"
+	);
+});
+
+test("a non-numeric time is rejected", () => {
+	expect(validateTimeRange({ startTime: "09:30", endTime: "abc" })).toBe(
+		"Invalid time"
+	);
+});

--- a/src/components/forms/time-range-input.tsx
+++ b/src/components/forms/time-range-input.tsx
@@ -120,6 +120,19 @@ export function TimeRangeInput({
 	);
 }
 
+/** Parse a strict "HH:MM" string into minutes-since-midnight, or null if the
+ * string is malformed or out of range (hours 0-23, minutes 0-59). */
+function timeToMinutes(time: string): number | null {
+	const match = /^(\d{1,2}):(\d{2})$/.exec(time);
+	if (!match) return null;
+
+	const hours = Number(match[1]);
+	const minutes = Number(match[2]);
+	if (hours > 23 || minutes > 59) return null;
+
+	return hours * 60 + minutes;
+}
+
 export function validateTimeRange(
 	value: TimeRangeValue | undefined
 ): string | null {
@@ -127,11 +140,12 @@ export function validateTimeRange(
 		return "Time range is required";
 	}
 
-	const [startH, startM] = value.startTime.split(":").map(Number);
-	const [endH, endM] = value.endTime.split(":").map(Number);
+	const startMinutes = timeToMinutes(value.startTime);
+	const endMinutes = timeToMinutes(value.endTime);
 
-	const startMinutes = startH * 60 + startM;
-	const endMinutes = endH * 60 + endM;
+	if (startMinutes === null || endMinutes === null) {
+		return "Invalid time";
+	}
 
 	if (endMinutes <= startMinutes) {
 		return "End time must be after start time";

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,9 +1,11 @@
 import {
 	formatActivityDuration,
 	formatDuration,
-	getDuration
+	getDuration,
+	stripTimezone
 } from "@/lib/date-utils";
 
+import { TZDate } from "@date-fns/tz";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { expect, test } from "vitest";
@@ -79,4 +81,51 @@ test("Should get pretty duration", () => {
 	expect(
 		formatDuration(getDuration(dateFromTime("09:00"), dateFromTime("09:14")))
 	).toEqual("14 mins");
+});
+
+// stripTimezone reads a Date's *local* calendar components and re-anchors them
+// at 00:00:00 UTC. Building inputs as `TZDate` instances in an explicit zone
+// (via @date-fns/tz) makes each assertion deterministic on any runner without
+// mutating global TZ state. `reinterpret` re-reads an instant in a given zone,
+// which is how a second stripTimezone pass sees its own (UTC-midnight) output.
+const reinterpret = (date: Date, tz: string) => new TZDate(date.getTime(), tz);
+
+test("stripTimezone maps a local date's calendar day to UTC midnight", () => {
+	// 23:30 on the 15th in UTC+10 -> the 15th at 00:00 UTC (time-of-day discarded).
+	const local = new TZDate(2024, 0, 15, 23, 30, "Australia/Brisbane");
+	expect(stripTimezone(local).toISOString()).toBe("2024-01-15T00:00:00.000Z");
+});
+
+test("stripTimezone always resets the time-of-day to UTC midnight", () => {
+	const result = stripTimezone(
+		new TZDate(2024, 5, 30, 17, 45, 12, 500, "Australia/Brisbane")
+	);
+	expect(result.getUTCHours()).toBe(0);
+	expect(result.getUTCMinutes()).toBe(0);
+	expect(result.getUTCSeconds()).toBe(0);
+	expect(result.getUTCMilliseconds()).toBe(0);
+});
+
+test("stripTimezone is idempotent in a non-negative UTC offset", () => {
+	// UTC+10: the first result (UTC midnight) reads back as the same local day,
+	// so a second application is a fixed point.
+	const once = stripTimezone(
+		new TZDate(2024, 0, 15, 23, 30, "Australia/Brisbane")
+	);
+	const twice = stripTimezone(reinterpret(once, "Australia/Brisbane"));
+	expect(twice.toISOString()).toBe(once.toISOString());
+});
+
+test("stripTimezone anchors on the local calendar day of a UTC-negative zone", () => {
+	// stripTimezone is defined by the *local* calendar day: a fresh picker date
+	// converts correctly in any zone (first assertion). It is only non-idempotent
+	// in UTC-negative zones because its own output (UTC midnight) reads back as
+	// the previous local day there. Melvin runs in UTC+10, so this never bites in
+	// practice; the test documents the semantics rather than a defect.
+	const once = stripTimezone(
+		new TZDate(2024, 0, 15, 23, 30, "America/New_York")
+	);
+	const twice = stripTimezone(reinterpret(once, "America/New_York"));
+	expect(once.toISOString()).toBe("2024-01-15T00:00:00.000Z");
+	expect(twice.toISOString()).toBe("2024-01-14T00:00:00.000Z");
 });

--- a/src/lib/group-participants.test.ts
+++ b/src/lib/group-participants.test.ts
@@ -1,0 +1,60 @@
+import {
+	appendParticipant,
+	removeParticipantAt,
+	setParticipantAt
+} from "@/lib/group-participants";
+import { MAX_ADDITIONAL_GROUP_PARTICIPANTS } from "@/schema/invoice-schema";
+import { expect, test } from "vitest";
+
+test("setParticipantAt replaces the id at the given index", () => {
+	expect(setParticipantAt(["a", "b", "c"], 1, "x")).toEqual(["a", "x", "c"]);
+});
+
+test("setParticipantAt does not mutate the input array", () => {
+	const original = ["a", "b", "c"];
+	setParticipantAt(original, 1, "x");
+	expect(original).toEqual(["a", "b", "c"]);
+});
+
+test("appendParticipant adds an empty slot", () => {
+	expect(appendParticipant(["a"])).toEqual(["a", ""]);
+});
+
+test("appendParticipant appends to an empty list", () => {
+	expect(appendParticipant([])).toEqual([""]);
+});
+
+test("appendParticipant is a no-op at the participant cap", () => {
+	const atCap = Array.from(
+		{ length: MAX_ADDITIONAL_GROUP_PARTICIPANTS },
+		(_, i) => `id-${i}`
+	);
+	expect(appendParticipant(atCap)).toBe(atCap);
+});
+
+test("appendParticipant is a no-op past the cap", () => {
+	const overCap = Array.from(
+		{ length: MAX_ADDITIONAL_GROUP_PARTICIPANTS + 1 },
+		(_, i) => `id-${i}`
+	);
+	expect(appendParticipant(overCap)).toBe(overCap);
+});
+
+test("removeParticipantAt removes the id at a middle index", () => {
+	expect(removeParticipantAt(["a", "b", "c"], 1)).toEqual(["a", "c"]);
+});
+
+test("removeParticipantAt handles the first index", () => {
+	expect(removeParticipantAt(["a", "b", "c"], 0)).toEqual(["b", "c"]);
+});
+
+test("removeParticipantAt handles the last index", () => {
+	expect(removeParticipantAt(["a", "b", "c"], 2)).toEqual(["a", "b"]);
+});
+
+test("removeParticipantAt is a no-op for an out-of-range index and returns a copy", () => {
+	const original = ["a", "b", "c"];
+	const result = removeParticipantAt(original, 5);
+	expect(result).toEqual(["a", "b", "c"]);
+	expect(result).not.toBe(original);
+});


### PR DESCRIPTION
Adds the first client-side unit tests to the repo (the pure-logic safety net for the upcoming multi-activity-form refactor) and fixes a validation bug those tests surfaced.

## Bug fixed

**`validateTimeRange` accepted invalid times.** It parsed `"HH:MM"` into minutes with no bounds or numeric check, so `"25:00"` (1500 minutes) passed and a malformed `"abc"` yielded `NaN`, where `NaN <= start` is `false` - both slipped through as valid. Now parses strictly via a `timeToMinutes` helper (hours 0-23, minutes 0-59, digits only) and returns `"Invalid time"` otherwise.

## Tests added

- **`src/lib/group-participants.test.ts`** - `setParticipantAt` (replace + no-mutation), `appendParticipant` (appends `""`, no-op at/past the `MAX_ADDITIONAL_GROUP_PARTICIPANTS` cap, checked by identity), `removeParticipantAt` (middle/first/last, out-of-range no-op returning a copy).
- **`src/components/forms/time-range-input.test.ts`** - `validateTimeRange` branches named after the rule: valid, end-before-start, equal times, undefined/partial input, and the newly-rejected out-of-range hours/minutes and non-numeric input.
- **`src/lib/date-utils.test.ts`** - `stripTimezone`: local calendar day -> UTC midnight, time-of-day always reset, idempotence, and its local-calendar-day semantics in a UTC-negative zone.

## Timezone handling in tests

Uses `@date-fns/tz`'s `TZDate` to build inputs in an explicit zone, rather than mutating `process.env.TZ`. This keeps every assertion deterministic on any runner and lands the `@date-fns/tz` dependency that the date-fns consolidation (issue #409) already plans to add.

## Note on `stripTimezone`

Left unchanged. It is only ever fed local wall-clock dates (`new Date()`, picker `day.toDate()`), so reading local components is correct for every caller. Its non-idempotence in UTC-negative zones is inherent to local-calendar-day semantics (not a bug) and never bites in practice - Melvin runs in UTC+10. A test documents the semantics.

## Verification

- `pnpm type-check` - clean
- `pnpm test:unit` - 146 passed
- `eslint` on all changed files - clean