### PR TITLE
HTTP hardening: security headers, safe Content-Disposition, dev-DB binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: melvin-db
     image: postgres:16
     ports:
-      - "127.0.0.1:5433:5432"
+      - "5433:5432"
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pass}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: melvin-db
     image: postgres:16
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     restart: unless-stopped
     environment:
-      - POSTGRES_PASSWORD=pass
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-pass}

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,26 @@ import { NextConfig } from "next";
 !process.env.SKIP_ENV_VALIDATION && require("./src/env/server.js");
 
 const nextConfig: NextConfig = {
-	output: "standalone"
+	output: "standalone",
+	async headers() {
+		return [
+			{
+				source: "/:path*",
+				headers: [
+					{ key: "X-Content-Type-Options", value: "nosniff" },
+					{ key: "X-Frame-Options", value: "DENY" },
+					{
+						key: "Referrer-Policy",
+						value: "strict-origin-when-cross-origin"
+					},
+					{
+						key: "Strict-Transport-Security",
+						value: "max-age=63072000; includeSubDomains"
+					}
+				]
+			}
+		];
+	}
 };
 
 export default nextConfig;

--- a/src/lib/content-disposition.test.ts
+++ b/src/lib/content-disposition.test.ts
@@ -1,0 +1,27 @@
+import { inlinePdfContentDisposition } from "@/lib/content-disposition";
+import { expect, test } from "vitest";
+
+test("emits a safe ASCII filename and an RFC 5987 fallback", () => {
+	expect(inlinePdfContentDisposition("INV-001")).toBe(
+		`inline; filename="INV-001"; filename*=UTF-8''INV-001`
+	);
+});
+
+test("replaces unsafe characters in the ASCII filename", () => {
+	// Spaces, slashes and quotes are not allowed in a bare filename token.
+	expect(inlinePdfContentDisposition('a/b c"d')).toBe(
+		`inline; filename="a_b_c_d"; filename*=UTF-8''a%2Fb%20c%22d`
+	);
+});
+
+test("strips header-injection attempts (CR/LF)", () => {
+	const disposition = inlinePdfContentDisposition("evil\r\nSet-Cookie: x=1");
+	expect(disposition).not.toMatch(/[\r\n]/);
+	expect(disposition).toContain(`filename="evil__Set-Cookie__x_1"`);
+});
+
+test("keeps unicode invoice numbers in the RFC 5987 fallback", () => {
+	expect(inlinePdfContentDisposition("Rechnung-Müller")).toBe(
+		`inline; filename="Rechnung-M_ller"; filename*=UTF-8''Rechnung-M%C3%BCller`
+	);
+});

--- a/src/lib/content-disposition.ts
+++ b/src/lib/content-disposition.ts
@@ -1,0 +1,13 @@
+/**
+ * Build an `inline` Content-Disposition header value for a PDF response.
+ *
+ * The invoice number is user-controlled, so the raw filename is never
+ * interpolated into the header directly. We emit two forms:
+ * - `filename="..."` sanitised to a safe ASCII token (RFC 6266 fallback), and
+ * - `filename*=UTF-8''...` percent-encoded (RFC 5987) so modern browsers still
+ *   recover the real, possibly-unicode name.
+ */
+export const inlinePdfContentDisposition = (fileName: string): string => {
+	const safeFileName = fileName.replace(/[^\w.-]/g, "_");
+	return `inline; filename="${safeFileName}"; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+};

--- a/src/pages/api/invoices/generate-pdf/[id].ts
+++ b/src/pages/api/invoices/generate-pdf/[id].ts
@@ -1,3 +1,4 @@
+import { inlinePdfContentDisposition } from "@/lib/content-disposition";
 import generatePDF from "@/lib/pdf-generation";
 import { getServerAuthSession } from "@/server/auth";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -25,7 +26,7 @@ const request = async (request: NextApiRequest, response: NextApiResponse) => {
 		}
 	);
 
-	if (!pdfString) {
+	if (!pdfString || !fileName) {
 		return response.status(404).send("Can't find PDF");
 	}
 
@@ -33,7 +34,7 @@ const request = async (request: NextApiRequest, response: NextApiResponse) => {
 		return response
 			.status(200)
 			.setHeader("Content-Type", "application/pdf")
-			.setHeader("Content-Disposition", `inline; filename="${fileName}"`)
+			.setHeader("Content-Disposition", inlinePdfContentDisposition(fileName))
 			.send(pdfString);
 	}
 
@@ -42,7 +43,7 @@ const request = async (request: NextApiRequest, response: NextApiResponse) => {
 	response.writeHead(200, {
 		"Content-Type": "application/pdf",
 		"Content-Length": pdfContent.length,
-		"Content-Disposition": `inline; filename="${fileName}"`
+		"Content-Disposition": inlinePdfContentDisposition(fileName)
 	});
 
 	response.end(pdfContent);


### PR DESCRIPTION
Closes #407.

Defense-in-depth HTTP hardening around the PII surface (participant names/numbers, provider bank details rendered in the browser and served as PDFs).

## Changes
- **Security headers** (`next.config.ts`): added `async headers()` on `/:path*` emitting `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, and `Strict-Transport-Security: max-age=63072000; includeSubDomains`.
  - Verified `DENY` is safe: `pdf-preview.tsx` renders via react-pdf canvas (base64 data, not an iframe of the API route) and `invoice-list.tsx` uses a plain anchor - nothing frames the generate-pdf URL.
- **Safe Content-Disposition** (`src/lib/content-disposition.ts` + `[id].ts`): the user-controlled `invoiceNo` is no longer interpolated raw into the header. A new pure helper sanitizes to a safe ASCII `filename="..."` token and adds an RFC 5987 `filename*=UTF-8''...` fallback so legitimate unicode invoice numbers keep their real name. Applied at both sinks. Unit-tested (ASCII sanitisation, CR/LF injection, unicode fallback).
- **Dev DB binding** (`docker-compose.yml`): bound the Postgres port to `127.0.0.1:5433:5432` (was published on all interfaces) and switched the password to `${POSTGRES_PASSWORD:-pass}` (default preserved so `pnpm db:up` keeps working).

## Out of scope (per issue)
Full CSP (needs tuning against Next's inline scripts/styles), `invoice-schema.ts` char tightening (sanitized at the sink instead), NextAuth cookie/CORS (defaults already correct).

## Notes
- Applying the compose change locally requires `pnpm db:nuke`, which **wipes local dev data** (acceptable for the dev DB).
- A report-only CSP is the natural next hardening step - worth raising as its own plan.

## Testing
- `tsc --noEmit` clean
- Full unit suite green (127 tests), including 4 new tests for the Content-Disposition helper
- eslint + prettier clean on changed files
