### PR TITLE
fix: make user.reset a complete wipe including sent-invoice versions

### DIFF
--- a/docs/adr/0004-invoice-versions-freeze-rendered-output.md
+++ b/docs/adr/0004-invoice-versions-freeze-rendered-output.md
@@ -28,3 +28,4 @@ Versions are not created by cascade, so they are not covered by the no-cascade-d
 - `getTotalOwing` / payment matching read frozen totals for sent invoices instead of recomputing.
 - ADR 0003's allow-recalc-with-warning now applies only to activities on draft invoices; trip edits touching a locked invoice's activities are rejected with an "amend first" error.
 - `paidAt` is stamped onto the paid version before an amendment clears the invoice-level field, preserving what was paid.
+- The `onDelete: Restrict` blocks only _accidental_ cascade deletes. A confirmed account reset (`user.reset`) is the sanctioned exception: it deletes the user's `InvoiceVersion` rows explicitly first, in a transaction, so a full "remove all my data" wipe succeeds rather than rolling back on the Restrict.

--- a/src/server/api/routers/user-router.integration.test.ts
+++ b/src/server/api/routers/user-router.integration.test.ts
@@ -145,14 +145,12 @@ test("reset clears all owned data and nulls the profile, leaving other users unt
 	);
 });
 
-// Characterization (see issue #408): a sent invoice makes reset's first
-// `client.deleteMany` cascade into Invoice and hit the ADR-0004
-// `InvoiceVersion` onDelete: Restrict. That single Postgres DELETE statement
-// rolls back whole, so nothing is deleted - not even the unrelated clean
-// client - and the profile-nulling never runs. It's a safe atomic no-op, but
-// it leaks a raw Prisma FK error to the caller (follow-up: return a clear
-// TRPCError instead).
-test("reset atomically no-ops when a sent invoice exists (fails on the first deleteMany, nothing is deleted)", async () => {
+// A confirmed account reset is the sanctioned exception to ADR-0004's
+// InvoiceVersion onDelete: Restrict (see issue #445): it deletes the frozen
+// versions explicitly first, so a sent invoice no longer blocks the wipe. The
+// whole account - including the sent invoice and its version - is cleared and
+// the profile nulled.
+test("reset wipes everything including a sent invoice and its frozen version", async () => {
 	const owner = await createTestUser();
 	const caller = callerFor(owner);
 	await caller.user.update({ user: PROFILE });
@@ -197,28 +195,40 @@ test("reset atomically no-ops when a sent invoice exists (fails on the first del
 		}
 	});
 
-	await expect(caller.user.reset()).rejects.toThrow();
+	// Sending froze a version - the record ADR-0004 restricts.
+	expect(
+		await prisma.invoiceVersion.count({
+			where: { invoice: { ownerId: owner.id } }
+		})
+	).toBe(1);
 
-	// Nothing deleted.
-	expect(await prisma.client.count({ where: { ownerId: owner.id } })).toBe(2);
+	await caller.user.reset();
+
+	// Everything is gone, including the sent invoice and its frozen version.
+	expect(await prisma.client.count({ where: { ownerId: owner.id } })).toBe(0);
 	expect(
 		await prisma.invoice.findUnique({ where: { id: sentInvoice.id } })
-	).not.toBeNull();
-	expect(await prisma.activity.count({ where: { ownerId: owner.id } })).toBe(2);
+	).toBeNull();
+	expect(await prisma.activity.count({ where: { ownerId: owner.id } })).toBe(0);
 	expect(
 		await prisma.activity.findUnique({ where: { id: cleanActivity.id } })
-	).not.toBeNull();
+	).toBeNull();
 	expect(await prisma.supportItem.count({ where: { ownerId: owner.id } })).toBe(
-		2
+		0
 	);
+	expect(
+		await prisma.invoiceVersion.count({
+			where: { invoice: { ownerId: owner.id } }
+		})
+	).toBe(0);
 
-	// Profile fields all unchanged (the nulling never ran).
-	const unchanged = await prisma.user.findUniqueOrThrow({
+	// Profile fields all nulled.
+	const nulled = await prisma.user.findUniqueOrThrow({
 		where: { id: owner.id }
 	});
-	expect(Number(unchanged.abn)).toBe(PROFILE.abn);
-	expect(unchanged.name).toBe(PROFILE.name);
-	expect(unchanged.bankName).toBe(PROFILE.bankName);
-	expect(Number(unchanged.bankNumber)).toBe(PROFILE.bankNumber);
-	expect(unchanged.bsb).toBe(PROFILE.bsb);
+	expect(nulled.abn).toBeNull();
+	expect(nulled.name).toBeNull();
+	expect(nulled.bankName).toBeNull();
+	expect(nulled.bankNumber).toBeNull();
+	expect(nulled.bsb).toBeNull();
 });

--- a/src/server/api/routers/user-router.ts
+++ b/src/server/api/routers/user-router.ts
@@ -73,44 +73,47 @@ export const userRouter = router({
 			});
 		}
 
-		// Deleting client will cascade delete invoices and activities
-		await ctx.prisma.client.deleteMany({
-			where: {
-				ownerId: userId
-			}
-		});
+		// A reset is a deliberate, confirmed "remove all my data" action, so it
+		// is the sanctioned exception to ADR-0004's InvoiceVersion onDelete:
+		// Restrict (which exists to block *accidental* cascade deletes). Delete
+		// the frozen versions explicitly first, otherwise the client cascade
+		// into Invoice would hit the Restrict and roll the whole wipe back.
+		// The sequence runs in a transaction so a mid-way failure can't leave
+		// financial records half-destroyed.
+		await ctx.prisma.$transaction([
+			ctx.prisma.invoiceVersion.deleteMany({
+				where: { invoice: { ownerId: userId } }
+			}),
 
-		// In case there are any orphaned invoices or activities, delete those too
-		await ctx.prisma.invoice.deleteMany({
-			where: {
-				ownerId: userId
-			}
-		});
+			// Deleting client will cascade delete invoices and activities
+			ctx.prisma.client.deleteMany({
+				where: { ownerId: userId }
+			}),
 
-		await ctx.prisma.activity.deleteMany({
-			where: {
-				ownerId: userId
-			}
-		});
+			// In case there are any orphaned invoices or activities, delete those too
+			ctx.prisma.invoice.deleteMany({
+				where: { ownerId: userId }
+			}),
 
-		await ctx.prisma.supportItem.deleteMany({
-			where: {
-				ownerId: userId
-			}
-		});
+			ctx.prisma.activity.deleteMany({
+				where: { ownerId: userId }
+			}),
 
-		await ctx.prisma.user.update({
-			where: {
-				id: userId
-			},
-			data: {
-				abn: null,
-				name: null,
-				bankName: null,
-				bankNumber: null,
-				bsb: null
-			}
-		});
+			ctx.prisma.supportItem.deleteMany({
+				where: { ownerId: userId }
+			}),
+
+			ctx.prisma.user.update({
+				where: { id: userId },
+				data: {
+					abn: null,
+					name: null,
+					bankName: null,
+					bankNumber: null,
+					bsb: null
+				}
+			})
+		]);
 	})
 });
 


### PR DESCRIPTION
## Summary

Rethinks #445. `user.reset` now performs a genuine complete account wipe instead of silently rolling back when a sent invoice exists.

The Reset Account dialog promises *"This action cannot be undone. This will reset your account and remove your data from our servers."* Previously, a sent invoice's frozen `InvoiceVersion` (ADR-0004 `onDelete: Restrict`) made reset's first `client.deleteMany` cascade into `Invoice` and hit the Restrict - the single `DELETE` rolled back whole, so nothing was deleted, the profile-nulling never ran, and a raw Prisma FK error leaked to the caller.

ADR-0004's `Restrict` is there to block *accidental* cascade deletes, not a deliberate, confirmed account wipe. So the fix is to make reset complete, not to block it more gracefully.

## Changes

- **`user-router.ts`**: `reset` now deletes the user's `InvoiceVersion` rows explicitly first (filtered via the `invoice` relation, as they have no `ownerId`), then runs the existing deletes and profile-null - all wrapped in `$transaction` so a mid-way failure can't leave financial records half-destroyed.
- **Integration test**: the #408 characterization test flips from "atomically no-ops when a sent invoice exists" to "wipes everything including a sent invoice and its frozen version".
- **ADR-0004**: added a consequence line recording account-reset as the sanctioned exception to the Restrict.

## Testing

- `pnpm test:integration src/server/api/routers/user-router.integration.test.ts` - 4 passed.

Closes #445
