### PR TITLE
feat: dashboard Unbilled list with travel/transport sub-lines

### DIFF
--- a/src/components/calendar/activity-sub-lines.test.ts
+++ b/src/components/calendar/activity-sub-lines.test.ts
@@ -1,0 +1,86 @@
+import { activitySubLines } from "@/components/calendar/activity-sub-lines";
+import { Prisma, RateType } from "@/generated/client";
+import { expect, test } from "vitest";
+
+const baseSupportItem = {
+	description: "Support Item",
+	weekdayCode: "04_104_0125_6_1",
+	weekdayRate: new Prisma.Decimal(55.47),
+	weeknightCode: "04_103_0125_6_1",
+	weeknightRate: new Prisma.Decimal(61.05),
+	saturdayCode: "04_105_0125_6_1",
+	saturdayRate: new Prisma.Decimal(77.81),
+	sundayCode: "04_106_0125_6_1",
+	sundayRate: new Prisma.Decimal(100.16),
+	rateType: RateType.HOUR,
+	isGroup: false
+};
+
+const fullyLoadedActivity = {
+	id: "activity_1",
+	date: new Date("2022-01-14"), // weekday
+	startTime: new Date("1970-01-01T09:00:00.000Z"),
+	endTime: new Date("1970-01-01T11:00:00.000Z"),
+	transitDuration: new Prisma.Decimal(25),
+	transitDistance: new Prisma.Decimal(18),
+	transportItems: [
+		{ type: "DISTANCE" as const, amount: new Prisma.Decimal(14) },
+		{
+			type: "PARKING" as const,
+			amount: new Prisma.Decimal(8.5),
+			note: "hospital carpark"
+		}
+	],
+	supportItem: baseSupportItem
+};
+
+test("splits Provider Travel from Activity Based Transport as quantities-only", () => {
+	const { travel, transport } = activitySubLines(fullyLoadedActivity);
+
+	// Provider Travel: labour minutes then non-labour km.
+	expect(travel).toEqual(["25 minutes", "18 km"]);
+
+	// Activity Based Transport: ABT km then the parking expense with its note.
+	expect(transport).toEqual(["14 km", "Parking - hospital carpark"]);
+});
+
+test("renders nothing when an activity has no travel or transport", () => {
+	const { travel, transport } = activitySubLines({
+		...fullyLoadedActivity,
+		transitDuration: null,
+		transitDistance: null,
+		transportItems: []
+	});
+
+	expect(travel).toEqual([]);
+	expect(transport).toEqual([]);
+});
+
+test("group activities show unapportioned quantities (money is apportioned, not the qty)", () => {
+	const { travel, transport } = activitySubLines({
+		...fullyLoadedActivity,
+		supportItem: { ...baseSupportItem, isGroup: true },
+		groupSize: 3
+	});
+
+	// Quantities are the raw figures the provider checks against their notes —
+	// group apportionment only affects the dollar total on the parent row.
+	expect(travel).toEqual(["25 minutes", "18 km"]);
+	expect(transport).toEqual(["14 km", "Parking - hospital carpark"]);
+});
+
+test("omits zero-value transport expenses, matching the invoice", () => {
+	const { transport } = activitySubLines({
+		...fullyLoadedActivity,
+		transportItems: [
+			{ type: "DISTANCE" as const, amount: new Prisma.Decimal(0) },
+			{
+				type: "TOLL" as const,
+				amount: new Prisma.Decimal(4.2),
+				note: null
+			}
+		]
+	});
+
+	expect(transport).toEqual(["Toll"]);
+});

--- a/src/components/calendar/activity-sub-lines.tsx
+++ b/src/components/calendar/activity-sub-lines.tsx
@@ -1,0 +1,70 @@
+import {
+	billableLines,
+	lineDetailsText,
+	type BillableActivity,
+	type TransitRateContext
+} from "@/lib/billing-lines";
+import { cn } from "@/lib/utils";
+
+interface Props {
+	activity: BillableActivity;
+	rateContext?: TransitRateContext;
+	className?: string;
+}
+
+/**
+ * The quantities-only Provider Travel and Activity Based Transport details for
+ * an activity, derived from the single billing path (`billableLines` +
+ * `lineDetailsText`) so they always agree with the invoice. Provider Travel
+ * (labour time + non-labour km) is kept on its own row, distinct from
+ * Activity Based Transport (ABT km + expenses).
+ * Deliberately carries no dollar figures — the money lives on the parent row;
+ * these exist so the provider can check quantities against their notes.
+ */
+export function activitySubLines(
+	activity: BillableActivity,
+	rateContext?: TransitRateContext
+): { travel: string[]; transport: string[] } {
+	const lines = billableLines(activity, rateContext, { forDisplay: true });
+
+	return {
+		travel: lines
+			.filter(
+				(line) => line.kind === "TRAVEL_TIME" || line.kind === "TRAVEL_KM"
+			)
+			.map((line) => lineDetailsText(line, activity)),
+		transport: lines
+			.filter((line) => line.kind === "ABT" || line.kind === "EXPENSE")
+			.map((line) => lineDetailsText(line, activity))
+	};
+}
+
+const ActivitySubLines = ({ activity, rateContext, className }: Props) => {
+	const { travel, transport } = activitySubLines(activity, rateContext);
+
+	if (travel.length === 0 && transport.length === 0) return null;
+
+	return (
+		<div
+			className={cn(
+				"text-muted-foreground flex flex-col gap-0.5 text-xs",
+				className
+			)}
+		>
+			{travel.length > 0 && (
+				<span>
+					<span className="font-medium">Provider Travel:</span>{" "}
+					{travel.join(" · ")}
+				</span>
+			)}
+			{transport.length > 0 && (
+				<span>
+					<span className="font-medium">Activity Based Transport:</span>{" "}
+					{transport.join(" · ")}
+				</span>
+			)}
+		</div>
+	);
+};
+
+export default ActivitySubLines;

--- a/src/components/calendar/calendar-agenda.tsx
+++ b/src/components/calendar/calendar-agenda.tsx
@@ -1,26 +1,32 @@
+import InfiniteList from "@/components/shared/infinite-list";
 import { useRateContext } from "@/components/shared/use-rate-context";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { formatActivityDuration, isHoliday } from "@/lib/date-utils";
-import { cn } from "@/lib/utils";
-import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
-import dayjs, { type Dayjs } from "dayjs";
+import { trpc } from "@/lib/trpc";
+import type { TransitRateContext } from "@/lib/billing-lines";
+import type { ActivityUnbilledListOutput } from "@/server/api/routers/activity-router";
+import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { Car, Clock } from "lucide-react";
+import { Car, CheckCircle2, Clock } from "lucide-react";
 import Link from "next/link";
+import ActivitySubLines from "./activity-sub-lines";
 
 dayjs.extend(utc);
 
-interface Props {
-	currentMonth: Dayjs;
-	activities: ActivityByDateRangeOutput;
-	isLoading: boolean;
-}
+type UnbilledActivities = ActivityUnbilledListOutput["activities"];
+type UnbilledActivity = UnbilledActivities[number];
 
-function groupByDate(activities: ActivityByDateRangeOutput) {
-	const groups: { date: string; activities: ActivityByDateRangeOutput }[] = [];
-	const map = new Map<string, ActivityByDateRangeOutput>();
+const currency = (value: number) =>
+	value.toLocaleString(undefined, {
+		style: "currency",
+		currency: "AUD",
+		minimumFractionDigits: 0
+	});
+
+function groupByDate(activities: UnbilledActivities) {
+	const groups: { date: string; activities: UnbilledActivities }[] = [];
+	const map = new Map<string, UnbilledActivities>();
 
 	for (const activity of activities) {
 		const key = dayjs(activity.date).format("YYYY-MM-DD");
@@ -28,7 +34,7 @@ function groupByDate(activities: ActivityByDateRangeOutput) {
 		if (existing) {
 			existing.push(activity);
 		} else {
-			const group: ActivityByDateRangeOutput = [activity];
+			const group: UnbilledActivities = [activity];
 			map.set(key, group);
 			groups.push({ date: key, activities: group });
 		}
@@ -37,73 +43,90 @@ function groupByDate(activities: ActivityByDateRangeOutput) {
 	return groups;
 }
 
-const CalendarAgenda = ({ currentMonth, activities, isLoading }: Props) => {
+const CalendarAgenda = () => {
 	const rateContext = useRateContext();
 
-	if (isLoading) {
-		return <AgendaSkeleton />;
-	}
+	const queryResult = trpc.activity.unbilledList.useInfiniteQuery(
+		{},
+		{ getNextPageParam: (lastPage) => lastPage.nextCursor }
+	);
+	const { data: summary } = trpc.activity.unbilledSummary.useQuery();
 
-	const groups = groupByDate(activities);
-
-	if (groups.length === 0) {
-		return (
-			<p className="text-muted-foreground py-12 text-center text-sm">
-				No activities in {currentMonth.format("MMMM YYYY")}.
-			</p>
-		);
-	}
+	const isEmpty =
+		queryResult.isSuccess &&
+		queryResult.data.pages.every((page) => page.activities.length === 0);
 
 	return (
-		<div className="flex flex-col divide-y">
-			{groups.map(({ date, activities: dayActivities }) => {
-				const day = dayjs(date);
-				const holiday = isHoliday(day.toDate());
-				const dayCost = getTotalCostOfActivities(dayActivities, rateContext, {
-					forDisplay: true
-				});
+		<div className="flex flex-col gap-3">
+			<div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 px-2">
+				<h2 className="text-base font-semibold">Unbilled</h2>
+				{summary && !isEmpty && (
+					<span className="text-muted-foreground text-sm">
+						{`${summary.count} ${
+							summary.count === 1 ? "activity" : "activities"
+						} · ${currency(summary.total)}`}
+					</span>
+				)}
+			</div>
 
-				return (
-					<div key={date} className="py-3">
-						<div className="flex items-center justify-between px-2 pb-2">
-							<div className="flex items-center gap-2">
-								<span className="text-sm font-semibold">
-									{day.format("ddd D MMM")}
-								</span>
-								{holiday && <Badge variant="success">Holiday</Badge>}
-							</div>
-							<span className="text-muted-foreground text-xs">
-								{dayCost.toLocaleString(undefined, {
-									style: "currency",
-									currency: "AUD",
-									minimumFractionDigits: 0
-								})}
-							</span>
-						</div>
+			{isEmpty ? (
+				<EmptyState />
+			) : (
+				<InfiniteList queryResult={queryResult} dataKey="activities">
+					{(activities) =>
+						groupByDate(activities).map(
+							({ date, activities: dayActivities }) => {
+								const day = dayjs(date);
+								const holiday = isHoliday(day.toDate());
+								const dayCost = getTotalCostOfActivities(
+									dayActivities,
+									rateContext,
+									{ forDisplay: true }
+								);
 
-						<div className="flex flex-col">
-							{dayActivities.map((activity) => (
-								<AgendaRow
-									key={activity.id}
-									activity={activity}
-									rateContext={rateContext}
-								/>
-							))}
-						</div>
-					</div>
-				);
-			})}
+								return (
+									<div key={date} className="py-3">
+										<div className="flex items-center justify-between px-2 pb-2">
+											<div className="flex items-center gap-2">
+												<span className="text-sm font-semibold">
+													{day.format("ddd D MMM YYYY")}
+												</span>
+												{holiday && <Badge variant="success">Holiday</Badge>}
+											</div>
+											<span className="text-muted-foreground text-xs">
+												{currency(dayCost)}
+											</span>
+										</div>
+
+										<div className="flex flex-col">
+											{dayActivities.map((activity) => (
+												<AgendaRow
+													key={activity.id}
+													activity={activity}
+													rateContext={rateContext}
+												/>
+											))}
+										</div>
+									</div>
+								);
+							}
+						)
+					}
+				</InfiniteList>
+			)}
 		</div>
 	);
 };
 
 interface AgendaRowProps {
-	activity: ActivityByDateRangeOutput[number];
-	rateContext?: { userTransitRatePerKm: number };
+	activity: UnbilledActivity;
+	rateContext?: TransitRateContext;
 }
 
 const AgendaRow = ({ activity, rateContext }: AgendaRowProps) => {
-	const isInvoiced = activity.invoiceId !== null;
+	// Every row here is unbilled, so an attached invoice is always a draft.
+	const draftInvoiceNo =
+		activity.invoiceId && activity.invoice ? activity.invoice.invoiceNo : null;
 	const cost = getTotalCostOfActivities([activity], rateContext, {
 		forDisplay: true
 	});
@@ -111,15 +134,19 @@ const AgendaRow = ({ activity, rateContext }: AgendaRowProps) => {
 	return (
 		<Link
 			href={`/dashboard/activities/${activity.id}`}
-			className={cn(
-				"hover:bg-muted/50 flex items-center justify-between gap-4 rounded-md px-2 py-2.5 transition-colors",
-				isInvoiced && "opacity-50"
-			)}
+			className="hover:bg-muted/50 flex items-start justify-between gap-4 rounded-md px-2 py-2.5 transition-colors"
 		>
 			<div className="flex min-w-0 flex-col gap-1">
-				<p className="truncate text-sm font-medium">
-					{activity.supportItem.description}
-				</p>
+				<div className="flex flex-wrap items-center gap-2">
+					<p className="truncate text-sm font-medium">
+						{activity.supportItem.description}
+					</p>
+					{draftInvoiceNo && (
+						<Badge variant="outline" className="text-xs">
+							Draft INV-{draftInvoiceNo}
+						</Badge>
+					)}
+				</div>
 
 				<div className="text-muted-foreground flex items-center gap-3 text-xs">
 					{activity.client && <span>{activity.client.name}</span>}
@@ -137,38 +164,23 @@ const AgendaRow = ({ activity, rateContext }: AgendaRowProps) => {
 							{formatActivityDuration(activity.startTime, activity.endTime)})
 						</span>
 					) : null}
-
-					{isInvoiced && activity.invoice && (
-						<span>Invoice #{activity.invoice.invoiceNo}</span>
-					)}
 				</div>
+
+				<ActivitySubLines activity={activity} rateContext={rateContext} />
 			</div>
 
 			<span className="text-sm font-medium whitespace-nowrap">
-				{cost.toLocaleString(undefined, {
-					style: "currency",
-					currency: "AUD",
-					minimumFractionDigits: 0
-				})}
+				{currency(cost)}
 			</span>
 		</Link>
 	);
 };
 
-const AgendaSkeleton = () => (
-	<div className="flex flex-col divide-y">
-		{Array.from({ length: 5 }).map((_, i) => (
-			<div key={i} className="py-3">
-				<div className="flex items-center justify-between px-2 pb-2">
-					<Skeleton className="h-4 w-24" />
-					<Skeleton className="h-3 w-12" />
-				</div>
-				<div className="flex flex-col gap-2 px-2">
-					<Skeleton className="h-12 w-full" />
-					<Skeleton className="h-12 w-full" />
-				</div>
-			</div>
-		))}
+const EmptyState = () => (
+	<div className="text-muted-foreground flex flex-col items-center gap-2 py-16 text-center">
+		<CheckCircle2 className="text-success h-8 w-8" />
+		<p className="text-sm font-medium">You&#39;re all caught up</p>
+		<p className="text-xs">Every activity has been billed.</p>
 	</div>
 );
 

--- a/src/components/calendar/calendar-day-modal.tsx
+++ b/src/components/calendar/calendar-day-modal.tsx
@@ -19,6 +19,7 @@ import utc from "dayjs/plugin/utc";
 import { Car, Clock, Link2, Pencil, Plus } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import ActivitySubLines from "./activity-sub-lines";
 
 dayjs.extend(utc);
 
@@ -192,6 +193,8 @@ const ActivityRow = ({ activity, rateContext }: ActivityRowProps) => {
 						Invoice #{activity.invoice.invoiceNo}
 					</span>
 				)}
+
+				<ActivitySubLines activity={activity} rateContext={rateContext} />
 			</div>
 
 			<span className="text-sm font-medium whitespace-nowrap">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -13,11 +13,26 @@ import { MultiActivityForm } from "@/components/activities/multi-activity-form";
 
 type ViewMode = "calendar" | "list";
 
+const VIEW_MODE_KEY = "calendar-view-mode";
+
+function getStoredViewMode(): ViewMode {
+	if (typeof window === "undefined") return "calendar";
+	return localStorage.getItem(VIEW_MODE_KEY) === "list" ? "list" : "calendar";
+}
+
 const CalendarView = () => {
 	const [currentMonth, setCurrentMonth] = useState(() =>
 		dayjs().startOf("month")
 	);
-	const [viewMode, setViewMode] = useState<ViewMode>("calendar");
+	// Safe to read localStorage in the initializer: `Layout` renders a skeleton
+	// (not this view) until the session resolves client-side, so CalendarView
+	// never renders during SSR and there is no server markup to mismatch.
+	const [viewMode, setViewMode] = useState<ViewMode>(getStoredViewMode);
+
+	const handleViewModeChange = useCallback((mode: ViewMode) => {
+		setViewMode(mode);
+		localStorage.setItem(VIEW_MODE_KEY, mode);
+	}, []);
 	const [selectedDay, setSelectedDay] = useState<Dayjs | null>(null);
 	const [quickAddDay, setQuickAddDay] = useState<Dayjs | null>(null);
 
@@ -73,39 +88,49 @@ const CalendarView = () => {
 	};
 
 	const isCurrentMonth = currentMonth.isSame(dayjs(), "month");
+	const isMonthView = viewMode === "calendar";
 
 	return (
 		<Layout className="mx-auto w-full max-w-7xl gap-4 px-2 sm:px-4">
 			<div className="flex items-center justify-between pb-4">
 				<div className="flex items-center gap-2">
-					<h1 className="text-xl font-semibold sm:text-2xl">
-						{currentMonth.format("MMMM YYYY")}
-					</h1>
+					{isMonthView && (
+						<h1 className="text-xl font-semibold sm:text-2xl">
+							{currentMonth.format("MMMM YYYY")}
+						</h1>
+					)}
 				</div>
 
 				<div className="flex items-center gap-1">
-					<ViewToggle viewMode={viewMode} onViewModeChange={setViewMode} />
+					<ViewToggle
+						viewMode={viewMode}
+						onViewModeChange={handleViewModeChange}
+					/>
 
-					<div className="bg-border mx-1 h-6 w-px" />
+					{isMonthView && (
+						<>
+							<div className="bg-border mx-1 h-6 w-px" />
 
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={goToToday}
-						disabled={isCurrentMonth}
-					>
-						Today
-					</Button>
-					<Button variant="ghost" size="icon" onClick={goToPreviousMonth}>
-						<ChevronLeft className="h-4 w-4" />
-					</Button>
-					<Button variant="ghost" size="icon" onClick={goToNextMonth}>
-						<ChevronRight className="h-4 w-4" />
-					</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={goToToday}
+								disabled={isCurrentMonth}
+							>
+								Today
+							</Button>
+							<Button variant="ghost" size="icon" onClick={goToPreviousMonth}>
+								<ChevronLeft className="h-4 w-4" />
+							</Button>
+							<Button variant="ghost" size="icon" onClick={goToNextMonth}>
+								<ChevronRight className="h-4 w-4" />
+							</Button>
+						</>
+					)}
 				</div>
 			</div>
 
-			{viewMode === "calendar" ? (
+			{isMonthView ? (
 				<CalendarMonth
 					currentMonth={currentMonth}
 					activities={activities ?? []}
@@ -113,11 +138,7 @@ const CalendarView = () => {
 					onDayClick={handleDayClick}
 				/>
 			) : (
-				<CalendarAgenda
-					currentMonth={currentMonth}
-					activities={activities ?? []}
-					isLoading={isLoading}
-				/>
+				<CalendarAgenda />
 			)}
 
 			<CalendarDayModal

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -64,7 +64,7 @@ export interface TransitRateContext {
 	userTransitRatePerKm?: number;
 }
 
-const DEFAULT_TRANSIT_RATE = 0.99;
+export const DEFAULT_TRANSIT_RATE = 0.99;
 
 export const DEFAULT_ACTIVITY_TRANSPORT_RATE = 0.99;
 

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -1,5 +1,8 @@
+import { getTotalCostOfActivities } from "@/lib/activity-utils";
+import { DEFAULT_TRANSIT_RATE } from "@/lib/billing-lines";
 import { checkActivityOverlap, formatOverlapError } from "@/lib/overlap-utils";
 import { baseListQueryInput } from "@/lib/trpc";
+import type { Prisma } from "@/generated/client";
 import { activitySchema } from "@/schema/activity-schema";
 import { paginate } from "@/server/api/owned";
 import { authedProcedure, router } from "@/server/api/trpc";
@@ -7,7 +10,10 @@ import { TRPCError, inferRouterOutputs } from "@trpc/server";
 import { z } from "zod";
 
 import dayjs from "dayjs";
-import { DEFAULT_LIST_LIMIT } from "./router.constants";
+import {
+	DEFAULT_LIST_LIMIT,
+	DEFAULT_UNBILLED_PAGE_SIZE
+} from "./router.constants";
 dayjs.extend(require("dayjs/plugin/utc"));
 dayjs.extend(require("dayjs/plugin/customParseFormat"));
 
@@ -100,6 +106,30 @@ const byIdActivitySelect = {
 	}
 };
 
+// "Unbilled" = work that still needs to be invoiced: either never attached to
+// an invoice, or attached to a draft still in status CREATED (never-sent drafts
+// and re-opened amendments). Sent (SENT) and paid (PAID) work is billed and
+// excluded. Deliberately broader than `activity.pending` (unattached only) and
+// deliberately NOT changing it — pick-up still means unattached.
+const unbilledActivityWhere = {
+	OR: [{ invoiceId: null }, { invoice: { status: "CREATED" } }]
+} satisfies Prisma.ActivityWhereInput;
+
+// List/summary need groupSize for correct group apportionment and the invoice
+// status to badge draft-attached rows, on top of the shared lean select.
+const unbilledActivitySelect = {
+	...defaultActivitySelect,
+	groupSize: true,
+	invoiceId: true,
+	invoice: {
+		select: {
+			invoiceNo: true,
+			id: true,
+			status: true
+		}
+	}
+};
+
 function getInvoiceIdWhereCondition(invoiceIdAssigned?: boolean) {
 	if (invoiceIdAssigned === undefined) return;
 
@@ -152,6 +182,54 @@ export const activityRouter = router({
 				nextCursor
 			};
 		}),
+	// The dashboard "Unbilled" list: all-time, oldest-first, infinite-scrolled.
+	unbilledList: authedProcedure
+		.input(baseListQueryInput)
+		.query(async ({ ctx, input }) => {
+			const limit = input.limit ?? DEFAULT_UNBILLED_PAGE_SIZE;
+
+			const { items: activities, nextCursor } = await paginate({
+				limit,
+				cursor: input.cursor,
+				query: ({ take, cursor }) =>
+					ctx.owned.activity.findMany({
+						select: unbilledActivitySelect,
+						take,
+						cursor,
+						where: unbilledActivityWhere,
+						orderBy: [{ date: "asc" }, { startTime: "asc" }]
+					})
+			});
+
+			return { activities, nextCursor };
+		}),
+	// Count + grand total for the whole unbilled set, computed by running every
+	// unbilled activity through the single billing path — never summed from the
+	// loaded pages, so the header stays correct regardless of how far the user
+	// has scrolled.
+	unbilledSummary: authedProcedure.query(async ({ ctx }) => {
+		const activities = await ctx.owned.activity.findMany({
+			select: { ...defaultActivitySelect, groupSize: true },
+			where: unbilledActivityWhere
+		});
+
+		const user = await ctx.prisma.user.findUnique({
+			where: { id: ctx.session.user.id },
+			select: { transitRatePerKm: true }
+		});
+
+		const rateContext = {
+			userTransitRatePerKm: Number(
+				user?.transitRatePerKm ?? DEFAULT_TRANSIT_RATE
+			)
+		};
+
+		const total = getTotalCostOfActivities(activities, rateContext, {
+			forDisplay: true
+		});
+
+		return { count: activities.length, total };
+	}),
 	pending: authedProcedure.query(async ({ ctx }) => {
 		const activities = await ctx.owned.activity.findMany({
 			select: defaultActivitySelect,
@@ -562,3 +640,7 @@ export type ActivityByIdOutput = inferRouterOutputs<
 export type ActivityByDateRangeOutput = inferRouterOutputs<
 	typeof activityRouter
 >["byDateRange"];
+
+export type ActivityUnbilledListOutput = inferRouterOutputs<
+	typeof activityRouter
+>["unbilledList"];

--- a/src/server/api/routers/router.constants.ts
+++ b/src/server/api/routers/router.constants.ts
@@ -1,1 +1,10 @@
+// The server-side default page size when a list caller supplies no `limit`.
+// Deliberately larger than `baseListQueryInput`'s max(100): that cap only
+// bounds a client-*supplied* limit, whereas this default lets internal
+// "fetch effectively all" callers (e.g. the invoice builder loading every
+// unassigned activity for a client) get their full set in one round-trip.
 export const DEFAULT_LIST_LIMIT = 1000;
+
+// The Unbilled list is infinite-scrolled, so it pages in modest chunks rather
+// than pulling everything at once.
+export const DEFAULT_UNBILLED_PAGE_SIZE = 50;

--- a/src/server/api/test/unbilled-activities.integration.test.ts
+++ b/src/server/api/test/unbilled-activities.integration.test.ts
@@ -1,0 +1,253 @@
+import { billableLines } from "@/lib/billing-lines";
+import type { InvoiceStatus, User } from "@/generated/client";
+import prisma from "@/server/prisma";
+import { beforeEach, describe, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "./harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function createSupportItem(owner: User) {
+	return prisma.supportItem.create({
+		data: {
+			description: "Support",
+			weekdayCode: "01_011_0107_1_1",
+			weekdayRate: 100,
+			rateType: "HOUR",
+			ownerId: owner.id
+		}
+	});
+}
+
+async function createClient(owner: User, name = "Client") {
+	return prisma.client.create({
+		data: { name, ownerId: owner.id, transitRatePerKm: 0.99 }
+	});
+}
+
+interface ActivityFixtureOptions {
+	date: string;
+	start?: string;
+	end?: string;
+	transitDistance?: number;
+	transitDuration?: number;
+	transport?: { type: "DISTANCE" | "PARKING"; amount: number; note?: string }[];
+	status?: InvoiceStatus | "PENDING";
+}
+
+async function createActivity(
+	owner: User,
+	clientId: string,
+	supportItemId: string,
+	options: ActivityFixtureOptions
+) {
+	let invoiceId: string | undefined;
+	if (options.status && options.status !== "PENDING") {
+		const invoice = await prisma.invoice.create({
+			data: {
+				invoiceNo: `INV-${options.status}-${options.date}`,
+				date: new Date(options.date),
+				status: options.status,
+				clientId,
+				ownerId: owner.id
+			}
+		});
+		invoiceId = invoice.id;
+	}
+
+	return prisma.activity.create({
+		data: {
+			date: new Date(options.date),
+			startTime: options.start ? new Date(options.start) : undefined,
+			endTime: options.end ? new Date(options.end) : undefined,
+			transitDistance: options.transitDistance,
+			transitDuration: options.transitDuration,
+			ownerId: owner.id,
+			clientId,
+			supportItemId,
+			invoiceId,
+			transportItems: options.transport
+				? {
+						create: options.transport.map((t) => ({
+							type: t.type,
+							amount: t.amount,
+							note: t.note
+						}))
+					}
+				: undefined
+		}
+	});
+}
+
+describe("activity.unbilledList / unbilledSummary", () => {
+	test("includes pending, draft and amended activities; excludes sent and paid", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner);
+
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-01-01T00:00:00.000Z",
+			start: "2024-01-01T09:00:00.000Z",
+			end: "2024-01-01T10:00:00.000Z",
+			status: "PENDING"
+		});
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-02-01T00:00:00.000Z",
+			start: "2024-02-01T09:00:00.000Z",
+			end: "2024-02-01T10:00:00.000Z",
+			status: "CREATED" // draft / re-opened amendment
+		});
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-03-01T00:00:00.000Z",
+			start: "2024-03-01T09:00:00.000Z",
+			end: "2024-03-01T10:00:00.000Z",
+			status: "SENT"
+		});
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-04-01T00:00:00.000Z",
+			start: "2024-04-01T09:00:00.000Z",
+			end: "2024-04-01T10:00:00.000Z",
+			status: "PAID"
+		});
+
+		const { activities } = await caller.activity.unbilledList({});
+		const dates = activities.map((a) => a.date.toISOString());
+
+		expect(dates).toEqual([
+			"2024-01-01T00:00:00.000Z",
+			"2024-02-01T00:00:00.000Z"
+		]);
+
+		const summary = await caller.activity.unbilledSummary();
+		expect(summary.count).toBe(2);
+	});
+
+	test("summary total equals the sum of billableLines over exactly the listed set", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner);
+
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-01-01T00:00:00.000Z",
+			start: "2024-01-01T09:00:00.000Z",
+			end: "2024-01-01T11:00:00.000Z",
+			transitDistance: 18,
+			transitDuration: 25,
+			transport: [
+				{ type: "DISTANCE", amount: 14 },
+				{ type: "PARKING", amount: 12.5, note: "hospital carpark" }
+			],
+			status: "PENDING"
+		});
+		// A SENT activity that must NOT contribute to the summary total.
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-05-01T00:00:00.000Z",
+			start: "2024-05-01T09:00:00.000Z",
+			end: "2024-05-01T10:00:00.000Z",
+			status: "SENT"
+		});
+
+		const { activities } = await caller.activity.unbilledList({});
+		const rateContext = { userTransitRatePerKm: 0.99 };
+		const expectedTotal = activities
+			.flatMap((a) => billableLines(a, rateContext, { forDisplay: true }))
+			.reduce((sum, line) => sum + line.total, 0);
+
+		const summary = await caller.activity.unbilledSummary();
+		expect(summary.total).toBeCloseTo(expectedTotal, 2);
+		expect(summary.total).toBeGreaterThan(0);
+	});
+
+	test("orders oldest first by date then start time, across all months", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner);
+
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-03-01T00:00:00.000Z",
+			start: "2024-03-01T14:00:00.000Z",
+			end: "2024-03-01T15:00:00.000Z",
+			status: "PENDING"
+		});
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-01-15T00:00:00.000Z",
+			start: "2024-01-15T09:00:00.000Z",
+			end: "2024-01-15T10:00:00.000Z",
+			status: "PENDING"
+		});
+		await createActivity(owner, client.id, supportItem.id, {
+			date: "2024-01-15T00:00:00.000Z",
+			start: "2024-01-15T07:00:00.000Z",
+			end: "2024-01-15T08:00:00.000Z",
+			status: "PENDING"
+		});
+
+		const { activities } = await caller.activity.unbilledList({});
+		// startTime is stored time-only (1970 epoch date), so assert the day and
+		// the time-of-day ordering separately.
+		const order = activities.map((a) => ({
+			date: a.date.toISOString(),
+			time: a.startTime ? a.startTime.toISOString().slice(11, 16) : undefined
+		}));
+		expect(order).toEqual([
+			{ date: "2024-01-15T00:00:00.000Z", time: "07:00" },
+			{ date: "2024-01-15T00:00:00.000Z", time: "09:00" },
+			{ date: "2024-03-01T00:00:00.000Z", time: "14:00" }
+		]);
+	});
+
+	test("paginates via cursor without repeating rows", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner);
+
+		for (let day = 1; day <= 5; day++) {
+			const date = `2024-01-0${day}T00:00:00.000Z`;
+			await createActivity(owner, client.id, supportItem.id, {
+				date,
+				start: `2024-01-0${day}T09:00:00.000Z`,
+				end: `2024-01-0${day}T10:00:00.000Z`,
+				status: "PENDING"
+			});
+		}
+
+		const first = await caller.activity.unbilledList({ limit: 2 });
+		expect(first.activities).toHaveLength(2);
+		expect(first.nextCursor).toBeDefined();
+
+		const second = await caller.activity.unbilledList({
+			limit: 2,
+			cursor: first.nextCursor
+		});
+
+		const firstIds = new Set(first.activities.map((a) => a.id));
+		expect(second.activities.some((a) => firstIds.has(a.id))).toBe(false);
+	});
+
+	test("does not leak other owners' activities", async () => {
+		const owner = await createTestUser("Owner");
+		const other = await createTestUser("Other");
+		const caller = callerFor(owner);
+
+		const otherSupportItem = await createSupportItem(other);
+		const otherClient = await createClient(other, "Other Client");
+		await createActivity(other, otherClient.id, otherSupportItem.id, {
+			date: "2024-01-01T00:00:00.000Z",
+			start: "2024-01-01T09:00:00.000Z",
+			end: "2024-01-01T10:00:00.000Z",
+			status: "PENDING"
+		});
+
+		const { activities } = await caller.activity.unbilledList({});
+		expect(activities).toHaveLength(0);
+
+		const summary = await caller.activity.unbilledSummary();
+		expect(summary.count).toBe(0);
+		expect(summary.total).toBe(0);
+	});
+});


### PR DESCRIPTION
Closes #420.

## What & why

Turns the dashboard's List mode into an all-time **Unbilled** view and adds quantities-only Travel/Transport sub-lines to activity rows, so the provider can check delivered work against their notes across every uninvoiced activity - not just the current month.

## Changes

- **Shared unbilled predicate** (`activity-router.ts`): `invoiceId: null` OR attached invoice `status: CREATED` (never-sent drafts + re-opened amendments). `activity.pending` is deliberately unchanged.
- **`activity.unbilledList`**: oldest-first (date asc / startTime asc), cursor pagination via `paginate` (50/page), selects the shared fields + `invoiceId`, `groupSize`, and invoice status.
- **`activity.unbilledSummary`**: count + grand total computed by running every unbilled activity through the single billing path (`billableLines`, `forDisplay: true`) - never summed from loaded pages.
- **Sub-line component** (`activity-sub-lines.tsx`): quantities-only, Provider Travel separated from Activity Based Transport, derived purely from `billableLines()` + `lineDetailsText()` (no second costing path). Rendered only when lines exist.
- **`CalendarAgenda`** reworked into the Unbilled list: infinite scroll, oldest-first day groups (header + per-day total), sub-lines, `Draft INV-NNN` badge for draft-attached rows, `Unbilled` header with `N activities · $total`, positive empty state.
- **`CalendarDayModal`**: sub-lines added to each row.
- **`calendar-view.tsx`**: month title / Today / prev-next shown only in Month mode; `ViewMode` persisted to localStorage (read in the lazy initializer - safe because `Layout` renders a skeleton until the session resolves, so this view never renders during SSR).
- **Tidy**: documented the intentional `DEFAULT_LIST_LIMIT` (1000) vs `baseListQueryInput` max(100) relationship (server "fetch-all" default vs client-supplied cap) and added `DEFAULT_UNBILLED_PAGE_SIZE`.

## Testing

- Integration (`unbilled-activities.integration.test.ts`): predicate across pending/draft/amended/sent/paid, summary total equals sum of `billableLines` over exactly the listed set, oldest-first ordering, cursor pagination, owner isolation.
- Unit (`activity-sub-lines.test.ts`): Travel/Transport split, empty case, group-activity quantities, zero-value expense omission.
- Full suite: 154 unit + 80 integration passing; type-check, lint (0 errors), and prettier clean.