### PR TITLE
refactor: consolidate on date-fns, drop dayjs (#409)

### DIFF
--- a/e2e/random/random-invoice.ts
+++ b/e2e/random/random-invoice.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import dayjs from "dayjs";
+import { format } from "date-fns";
 
 export const randomInvoice = ({
 	invoiceNo,
@@ -23,7 +23,7 @@ export const randomInvoice = ({
 			supportItemId: supportItemId ?? "",
 			ownerId: ownerId ?? "",
 			clientId: clientId ?? "",
-			date: dayjs().format("YYYY-MM-DD"),
+			date: format(new Date(), "yyyy-MM-dd"),
 			startTime: "13:00",
 			endTime: "14:00",
 			transitDistance: faker.number.int({ min: 1, max: 20 }),

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -2,7 +2,7 @@ import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import prisma from "@/server/prisma";
 import { Page } from "@playwright/test";
 import { randomUUID } from "crypto";
-import dayjs from "dayjs";
+import { addMonths } from "date-fns";
 import { randomClient } from "./random/random-client";
 import { randomSupportItem } from "./random/random-support-item";
 
@@ -18,7 +18,7 @@ export const testUser = {
 	bankNumber: BigInt("987654321"),
 	sessions: {
 		create: {
-			expires: dayjs().add(1, "month").toDate(),
+			expires: addMonths(new Date(), 1),
 			sessionToken: randomUUID()
 		}
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,24 @@ const eslintConfig = defineConfig([
 	prettier,
 	{
 		rules: {
-			"@typescript-eslint/no-require-imports": "off"
+			"@typescript-eslint/no-require-imports": "off",
+			"no-restricted-imports": [
+				"error",
+				{
+					paths: [
+						{
+							name: "dayjs",
+							message: "Use date-fns (+ @date-fns/tz for UTC) instead of dayjs."
+						}
+					],
+					patterns: [
+						{
+							group: ["dayjs/*"],
+							message: "Use date-fns (+ @date-fns/tz for UTC) instead of dayjs."
+						}
+					]
+				}
+			]
 		}
 	},
 	// Override default ignores of eslint-config-next.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",
 		"date-fns": "4.1.0",
-		"dayjs": "1.11.21",
 		"dotenv": "17.3.1",
 		"jspdf": "4.2.1",
 		"jspdf-autotable": "5.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
-      dayjs:
-        specifier: 1.11.21
-        version: 1.11.21
       dotenv:
         specifier: 17.3.1
         version: 17.3.1
@@ -3500,9 +3497,6 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
-
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -8867,8 +8861,6 @@ snapshots:
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
-
-  dayjs@1.11.21: {}
 
   debug@3.2.7:
     dependencies:

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,12 +2,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { randomClient } from "../e2e/random/random-client";
 import { randomInvoice } from "../e2e/random/random-invoice";
 import { PrismaClient, InvoiceStatus } from "@/generated/client";
-
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-dayjs.extend(customParseFormat);
+import { parseUtcTime, utcDate } from "@/lib/date-utils";
 
 const adapter = new PrismaPg({
 	connectionString: process.env.DATABASE_URL
@@ -77,16 +72,16 @@ async function main() {
 			data: {
 				...invoice,
 				ownerId: user.id,
-				date: dayjs().toDate(),
+				date: new Date(),
 				clientId: client.id,
 				status:
 					invoiceStatuses[Math.floor(Math.random() * invoiceStatuses.length)],
 				activities: {
 					create: invoice.activities.map((activity) => ({
 						...activity,
-						date: dayjs.utc(activity.date, "YYYY-MM-DD").toDate(),
-						startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
-						endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
+						date: utcDate(activity.date),
+						startTime: parseUtcTime(activity.startTime),
+						endTime: parseUtcTime(activity.endTime),
 						transitDistance: Number(activity.transitDistance),
 						transitDuration: Number(activity.transitDuration)
 					}))

--- a/src/components/activities/activity-form.tsx
+++ b/src/components/activities/activity-form.tsx
@@ -17,7 +17,7 @@ import {
 	PopoverContent,
 	PopoverTrigger
 } from "@/components/ui/popover";
-import { stripTimezone } from "@/lib/date-utils";
+import { stripTimezone, utcDate } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { ActivitySchema, activitySchema } from "@/schema/activity-schema";
@@ -37,11 +37,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
-import dayjs from "dayjs";
 import { useSearchParams } from "next/navigation";
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/localizedFormat"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
 
 interface Props {
 	existingActivity?: Partial<ActivityByIdOutput> & {
@@ -99,10 +95,10 @@ const ActivityForm = ({ existingActivity }: Props) => {
 			supportItemId: existingActivity?.supportItem?.id ?? "",
 			clientId: existingActivity?.client?.id ?? "",
 			startTime: existingActivity?.startTime
-				? dayjs.utc(existingActivity?.startTime).format("HH:mm")
+				? format(utcDate(existingActivity.startTime), "HH:mm")
 				: "",
-			endTime: existingActivity?.startTime
-				? dayjs.utc(existingActivity?.endTime).format("HH:mm")
+			endTime: existingActivity?.endTime
+				? format(utcDate(existingActivity.endTime), "HH:mm")
 				: "",
 			itemDistance: existingActivity?.itemDistance ?? undefined,
 			transitDistance: existingActivity?.transitDistance

--- a/src/components/activities/activity-list.tsx
+++ b/src/components/activities/activity-list.tsx
@@ -6,12 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import {
 	formatActivityDuration,
-	isHoliday as isDateHoliday
+	isHoliday as isDateHoliday,
+	utcDate
 } from "@/lib/date-utils";
 import { groupBy } from "@/lib/generic-utils";
 import { trpc } from "@/lib/trpc";
 import { ActivityListOutput } from "@/server/api/routers/activity-router";
-import dayjs from "dayjs";
+import { format } from "date-fns";
 import { Car, CircleDollarSign, Clock, User } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -27,7 +28,7 @@ const groupActivitiesByDate = (
 	activities?: ActivityListOutput["activities"]
 ) =>
 	activities
-		? groupBy(activities, (activity) => dayjs(activity.date).toString())
+		? groupBy(activities, (activity) => new Date(activity.date).toUTCString())
 		: {};
 
 function ActivityList({
@@ -75,7 +76,7 @@ function ActivityList({
 						([date, groupedActivities]) => (
 							<div key={date} className="mb-4 overflow-hidden">
 								<div className="flex w-full items-center gap-2 px-4 py-2 text-left">
-									{dayjs(date).format("dddd D MMM.")}
+									{format(new Date(date), "EEEE d MMM.")}
 									{isDateHoliday(date) && (
 										<Badge variant="success">Holiday</Badge>
 									)}
@@ -101,10 +102,15 @@ function ActivityList({
 												) : (
 													<div className="text-foreground/80 flex items-center gap-2 whitespace-nowrap">
 														<Clock className="h-4 w-4" />
-														{dayjs
-															.utc(activity.startTime)
-															.format("HH:mm")} -{" "}
-														{dayjs.utc(activity.endTime).format("HH:mm")}
+														{format(
+															utcDate(activity.startTime ?? new Date(0)),
+															"HH:mm"
+														)}{" "}
+														-{" "}
+														{format(
+															utcDate(activity.endTime ?? new Date(0)),
+															"HH:mm"
+														)}
 														<span className="hidden md:inline">
 															(
 															{activity.startTime &&

--- a/src/components/activities/activity-page.tsx
+++ b/src/components/activities/activity-page.tsx
@@ -30,8 +30,8 @@ import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { toast } from "react-toastify";
 
-import dayjs from "dayjs";
-dayjs.extend(require("dayjs/plugin/utc"));
+import { utcDate } from "@/lib/date-utils";
+import { differenceInMinutes, format } from "date-fns";
 
 const formatDuration = (minutes: number) => {
 	const hours = Math.floor(minutes / 60);
@@ -111,16 +111,20 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 
 	const hasTimes = Boolean(activity.startTime && activity.endTime);
 	const durationMinutes = hasTimes
-		? dayjs.utc(activity.endTime).diff(dayjs.utc(activity.startTime), "minute")
+		? differenceInMinutes(
+				activity.endTime ?? new Date(0),
+				activity.startTime ?? new Date(0)
+			)
 		: 0;
 
 	return (
 		<div className="flex flex-col items-center px-4 pb-24 md:pb-8">
 			<Head>
 				<title>
-					{`${activity.supportItem.description} - ${dayjs
-						.utc(activity.date)
-						.format("DD/MM")} | Melvin`}
+					{`${activity.supportItem.description} - ${format(
+						utcDate(activity.date),
+						"dd/MM"
+					)} | Melvin`}
 				</title>
 			</Head>
 			<div className="flex w-full max-w-3xl flex-col gap-6">
@@ -128,7 +132,7 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 					<div className="flex items-start justify-between gap-3">
 						<div className="flex min-w-0 flex-col gap-1">
 							<p className="text-primary text-xs font-medium">
-								{dayjs.utc(activity.date).format("dddd, D MMMM YYYY")}
+								{format(utcDate(activity.date), "EEEE, d MMMM yyyy")}
 							</p>
 							<h1 className="text-lg font-semibold tracking-tight text-balance md:text-xl">
 								{activity.supportItem.description}
@@ -184,8 +188,8 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 					<dl className="bg-card grid grid-cols-1 divide-y overflow-hidden rounded-xl border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
 						{hasTimes ? (
 							<Fact icon={Clock} label="Time">
-								{dayjs.utc(activity.startTime).format("h:mma")} -{" "}
-								{dayjs.utc(activity.endTime).format("h:mma")}
+								{format(utcDate(activity.startTime ?? new Date(0)), "h:mmaaa")}{" "}
+								- {format(utcDate(activity.endTime ?? new Date(0)), "h:mmaaa")}
 								<span className="text-foreground/50 font-normal">
 									{" "}
 									· {formatDuration(durationMinutes)}

--- a/src/components/activities/activity-trip-summary.tsx
+++ b/src/components/activities/activity-trip-summary.tsx
@@ -5,10 +5,9 @@ import {
 } from "@/lib/trip-utils";
 import type { ActivityByIdOutput } from "@/server/api/routers/activity-router";
 import { cn } from "@/lib/utils";
-import dayjs from "dayjs";
+import { utcDate } from "@/lib/date-utils";
+import { format } from "date-fns";
 import Link from "next/link";
-
-dayjs.extend(require("dayjs/plugin/utc"));
 
 type Trip = NonNullable<ActivityByIdOutput["trip"]>;
 type Leg = Trip["activities"][number];
@@ -23,9 +22,10 @@ const positionLabel = (index: number, count: number) => {
 
 const timeSpan = (leg: Leg) =>
 	leg.startTime && leg.endTime
-		? `${dayjs.utc(leg.startTime).format("h:mma")} - ${dayjs
-				.utc(leg.endTime)
-				.format("h:mma")}`
+		? `${format(utcDate(leg.startTime), "h:mmaaa")} - ${format(
+				utcDate(leg.endTime),
+				"h:mmaaa"
+			)}`
 		: null;
 
 function LegRow({

--- a/src/components/calendar/calendar-agenda.tsx
+++ b/src/components/calendar/calendar-agenda.tsx
@@ -2,17 +2,14 @@ import InfiniteList from "@/components/shared/infinite-list";
 import { useRateContext } from "@/components/shared/use-rate-context";
 import { Badge } from "@/components/ui/badge";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
-import { formatActivityDuration, isHoliday } from "@/lib/date-utils";
+import { formatActivityDuration, isHoliday, utcDate } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import type { TransitRateContext } from "@/lib/billing-lines";
 import type { ActivityUnbilledListOutput } from "@/server/api/routers/activity-router";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
+import { format, parse } from "date-fns";
 import { Car, CheckCircle2, Clock } from "lucide-react";
 import Link from "next/link";
 import ActivitySubLines from "./activity-sub-lines";
-
-dayjs.extend(utc);
 
 type UnbilledActivities = ActivityUnbilledListOutput["activities"];
 type UnbilledActivity = UnbilledActivities[number];
@@ -29,7 +26,7 @@ function groupByDate(activities: UnbilledActivities) {
 	const map = new Map<string, UnbilledActivities>();
 
 	for (const activity of activities) {
-		const key = dayjs(activity.date).format("YYYY-MM-DD");
+		const key = format(new Date(activity.date), "yyyy-MM-dd");
 		const existing = map.get(key);
 		if (existing) {
 			existing.push(activity);
@@ -76,8 +73,8 @@ const CalendarAgenda = () => {
 					{(activities) =>
 						groupByDate(activities).map(
 							({ date, activities: dayActivities }) => {
-								const day = dayjs(date);
-								const holiday = isHoliday(day.toDate());
+								const day = parse(date, "yyyy-MM-dd", new Date());
+								const holiday = isHoliday(day);
 								const dayCost = getTotalCostOfActivities(
 									dayActivities,
 									rateContext,
@@ -89,7 +86,7 @@ const CalendarAgenda = () => {
 										<div className="flex items-center justify-between px-2 pb-2">
 											<div className="flex items-center gap-2">
 												<span className="text-sm font-semibold">
-													{day.format("ddd D MMM YYYY")}
+													{format(day, "EEE d MMM yyyy")}
 												</span>
 												{holiday && <Badge variant="success">Holiday</Badge>}
 											</div>
@@ -159,8 +156,8 @@ const AgendaRow = ({ activity, rateContext }: AgendaRowProps) => {
 					) : activity.startTime && activity.endTime ? (
 						<span className="flex items-center gap-1">
 							<Clock className="h-3 w-3" />
-							{dayjs.utc(activity.startTime).format("H:mm")} -{" "}
-							{dayjs.utc(activity.endTime).format("H:mm")} (
+							{format(utcDate(activity.startTime), "H:mm")} -{" "}
+							{format(utcDate(activity.endTime), "H:mm")} (
 							{formatActivityDuration(activity.startTime, activity.endTime)})
 						</span>
 					) : null}

--- a/src/components/calendar/calendar-day-cell.tsx
+++ b/src/components/calendar/calendar-day-cell.tsx
@@ -1,20 +1,18 @@
 import { cn } from "@/lib/utils";
 import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
-import dayjs, { type Dayjs } from "dayjs";
-import utc from "dayjs/plugin/utc";
+import { utcDate } from "@/lib/date-utils";
+import { format, getDate, getDay } from "date-fns";
 import Link from "next/link";
-
-dayjs.extend(utc);
 
 const MAX_VISIBLE_ACTIVITIES = 3;
 
 interface Props {
-	day: Dayjs;
+	day: Date;
 	activities: ActivityByDateRangeOutput;
 	isCurrentMonth: boolean;
 	isToday: boolean;
 	isFocused: boolean;
-	onDayClick: (day: Dayjs) => void;
+	onDayClick: (day: Date) => void;
 }
 
 const CalendarDayCell = ({
@@ -36,7 +34,7 @@ const CalendarDayCell = ({
 			tabIndex={isFocused ? 0 : -1}
 			className={cn(
 				"border-border hover:bg-accent/50 flex h-16 cursor-pointer flex-col border-r border-b p-1 text-left transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset sm:h-32",
-				day.day() === 1 && "border-l",
+				getDay(day) === 1 && "border-l",
 				!isCurrentMonth && "bg-muted/30",
 				isCurrentMonth && !hasActivities && "bg-muted/10",
 				isFocused && "ring-ring ring-2 ring-inset"
@@ -50,7 +48,7 @@ const CalendarDayCell = ({
 						isToday && "bg-primary text-primary-foreground font-semibold"
 					)}
 				>
-					{day.date()}
+					{getDate(day)}
 				</span>
 			</div>
 
@@ -100,7 +98,7 @@ const ActivityCard = ({ activity }: ActivityCardProps) => {
 	const timeLabel = activity.itemDistance
 		? `${activity.itemDistance}km`
 		: activity.startTime
-			? dayjs.utc(activity.startTime).format("H:mm")
+			? format(utcDate(activity.startTime), "H:mm")
 			: "";
 
 	const clientName = activity.client?.name ?? "";

--- a/src/components/calendar/calendar-day-modal.tsx
+++ b/src/components/calendar/calendar-day-modal.tsx
@@ -11,20 +11,17 @@ import {
 } from "@/components/ui/dialog";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { trpc } from "@/lib/trpc";
-import { formatActivityDuration, isHoliday } from "@/lib/date-utils";
+import { formatActivityDuration, isHoliday, utcDate } from "@/lib/date-utils";
 import { cn } from "@/lib/utils";
 import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
-import dayjs, { type Dayjs } from "dayjs";
-import utc from "dayjs/plugin/utc";
+import { format } from "date-fns";
 import { Car, Clock, Link2, Pencil, Plus } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import ActivitySubLines from "./activity-sub-lines";
 
-dayjs.extend(utc);
-
 interface Props {
-	day: Dayjs | null;
+	day: Date | null;
 	activities: ActivityByDateRangeOutput;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -46,13 +43,13 @@ const CalendarDayModal = ({
 
 	const existingTripId = activities.find((a) => a.tripId)?.tripId;
 	const { data: existingTrip } = trpc.trip.getByDate.useQuery(
-		{ date: day?.toDate() ?? new Date() },
+		{ date: day ?? new Date() },
 		{ enabled: !!day && !!existingTripId }
 	);
 
 	if (!day) return null;
 
-	const holiday = isHoliday(day.toDate());
+	const holiday = isHoliday(day);
 
 	const eligibleForTrip = activities.filter(
 		(a) => a.startTime && a.endTime && !a.tripId
@@ -65,7 +62,7 @@ const CalendarDayModal = ({
 			<DialogContent className="max-h-[100dvh] overflow-y-auto max-sm:h-full max-sm:max-w-full max-sm:rounded-none sm:max-h-[80vh] sm:max-w-lg">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
-						{day.format("dddd D MMMM")}
+						{format(day, "EEEE d MMMM")}
 						{holiday && <Badge variant="success">Holiday</Badge>}
 					</DialogTitle>
 				</DialogHeader>
@@ -116,7 +113,7 @@ const CalendarDayModal = ({
 
 			<TripEditorModal
 				mode="create"
-				date={day.toDate()}
+				date={day}
 				activities={activities}
 				open={tripBuilderOpen}
 				onOpenChange={setTripBuilderOpen}
@@ -181,8 +178,8 @@ const ActivityRow = ({ activity, rateContext }: ActivityRowProps) => {
 					) : activity.startTime && activity.endTime ? (
 						<span className="flex items-center gap-1">
 							<Clock className="h-3 w-3" />
-							{dayjs.utc(activity.startTime).format("H:mm")} -{" "}
-							{dayjs.utc(activity.endTime).format("H:mm")} (
+							{format(utcDate(activity.startTime), "H:mm")} -{" "}
+							{format(utcDate(activity.endTime), "H:mm")} (
 							{formatActivityDuration(activity.startTime, activity.endTime)})
 						</span>
 					) : null}

--- a/src/components/calendar/calendar-month.tsx
+++ b/src/components/calendar/calendar-month.tsx
@@ -1,33 +1,41 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
-import dayjs, { type Dayjs } from "dayjs";
+import {
+	addDays,
+	format,
+	getDay,
+	getDaysInMonth,
+	getMonth,
+	startOfMonth,
+	subDays
+} from "date-fns";
 import { useCallback, useMemo, useRef, useState } from "react";
 import CalendarDayCell from "./calendar-day-cell";
 
 const DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 
 interface Props {
-	currentMonth: Dayjs;
+	currentMonth: Date;
 	activities: ActivityByDateRangeOutput;
 	isLoading: boolean;
-	onDayClick: (day: Dayjs) => void;
+	onDayClick: (day: Date) => void;
 }
 
-function getCalendarDays(month: Dayjs) {
-	const firstOfMonth = month.startOf("month");
-	// dayjs .day() is 0=Sun, we want 0=Mon
-	const startDay = (firstOfMonth.day() + 6) % 7;
-	const calendarStart = firstOfMonth.subtract(startDay, "day");
+function getCalendarDays(month: Date) {
+	const firstOfMonth = startOfMonth(month);
+	// getDay is 0=Sun, we want 0=Mon
+	const startDay = (getDay(firstOfMonth) + 6) % 7;
+	const calendarStart = subDays(firstOfMonth, startDay);
 
-	const daysInMonth = month.daysInMonth();
+	const daysInMonth = getDaysInMonth(month);
 	const totalCells = startDay + daysInMonth;
 	const totalRows = Math.ceil(totalCells / 7);
 	const totalDays = totalRows * 7;
 
-	const days: Dayjs[] = [];
+	const days: Date[] = [];
 	for (let i = 0; i < totalDays; i++) {
-		days.push(calendarStart.add(i, "day"));
+		days.push(addDays(calendarStart, i));
 	}
 
 	return days;
@@ -36,7 +44,7 @@ function getCalendarDays(month: Dayjs) {
 function groupActivitiesByDate(activities: ActivityByDateRangeOutput) {
 	const map = new Map<string, ActivityByDateRangeOutput>();
 	for (const activity of activities) {
-		const key = dayjs(activity.date).format("YYYY-MM-DD");
+		const key = format(new Date(activity.date), "yyyy-MM-dd");
 		const existing = map.get(key);
 		if (existing) {
 			existing.push(activity);
@@ -59,7 +67,7 @@ const CalendarMonth = ({
 		[activities]
 	);
 
-	const today = dayjs().format("YYYY-MM-DD");
+	const today = format(new Date(), "yyyy-MM-dd");
 	const gridRef = useRef<HTMLDivElement>(null);
 
 	// Track focused day index for keyboard navigation
@@ -130,12 +138,12 @@ const CalendarMonth = ({
 				ref={gridRef}
 				className="grid grid-cols-7"
 				role="grid"
-				aria-label={currentMonth.format("MMMM YYYY")}
+				aria-label={format(currentMonth, "MMMM yyyy")}
 				onKeyDown={handleKeyDown}
 			>
 				{days.map((day, index) => {
-					const dateKey = day.format("YYYY-MM-DD");
-					const isCurrentMonth = day.month() === currentMonth.month();
+					const dateKey = format(day, "yyyy-MM-dd");
+					const isCurrentMonth = getMonth(day) === getMonth(currentMonth);
 					const isToday = dateKey === today;
 					const dayActivities = activitiesByDate.get(dateKey) ?? [];
 

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -3,7 +3,13 @@ import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
-import dayjs, { type Dayjs } from "dayjs";
+import {
+	addMonths,
+	format,
+	isSameMonth,
+	startOfMonth,
+	subMonths
+} from "date-fns";
 import { CalendarDays, ChevronLeft, ChevronRight, List } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import CalendarAgenda from "./calendar-agenda";
@@ -22,7 +28,7 @@ function getStoredViewMode(): ViewMode {
 
 const CalendarView = () => {
 	const [currentMonth, setCurrentMonth] = useState(() =>
-		dayjs().startOf("month")
+		startOfMonth(new Date())
 	);
 	// Safe to read localStorage in the initializer: `Layout` renders a skeleton
 	// (not this view) until the session resolves client-side, so CalendarView
@@ -33,11 +39,11 @@ const CalendarView = () => {
 		setViewMode(mode);
 		localStorage.setItem(VIEW_MODE_KEY, mode);
 	}, []);
-	const [selectedDay, setSelectedDay] = useState<Dayjs | null>(null);
-	const [quickAddDay, setQuickAddDay] = useState<Dayjs | null>(null);
+	const [selectedDay, setSelectedDay] = useState<Date | null>(null);
+	const [quickAddDay, setQuickAddDay] = useState<Date | null>(null);
 
-	const startDate = currentMonth.toDate();
-	const endDate = currentMonth.add(1, "month").toDate();
+	const startDate = currentMonth;
+	const endDate = addMonths(currentMonth, 1);
 
 	const {
 		data: activities,
@@ -51,7 +57,7 @@ const CalendarView = () => {
 	const activitiesByDate = useMemo(() => {
 		const map = new Map<string, ActivityByDateRangeOutput>();
 		for (const activity of activities ?? []) {
-			const key = dayjs(activity.date).format("YYYY-MM-DD");
+			const key = format(new Date(activity.date), "yyyy-MM-dd");
 			const existing = map.get(key);
 			if (existing) {
 				existing.push(activity);
@@ -63,10 +69,10 @@ const CalendarView = () => {
 	}, [activities]);
 
 	const selectedDayActivities = selectedDay
-		? (activitiesByDate.get(selectedDay.format("YYYY-MM-DD")) ?? [])
+		? (activitiesByDate.get(format(selectedDay, "yyyy-MM-dd")) ?? [])
 		: [];
 
-	const handleDayClick = useCallback((day: Dayjs) => {
+	const handleDayClick = useCallback((day: Date) => {
 		setSelectedDay(day);
 	}, []);
 
@@ -76,18 +82,18 @@ const CalendarView = () => {
 	}, [selectedDay]);
 
 	const goToPreviousMonth = () => {
-		setCurrentMonth((prev) => prev.subtract(1, "month"));
+		setCurrentMonth((prev) => subMonths(prev, 1));
 	};
 
 	const goToNextMonth = () => {
-		setCurrentMonth((prev) => prev.add(1, "month"));
+		setCurrentMonth((prev) => addMonths(prev, 1));
 	};
 
 	const goToToday = () => {
-		setCurrentMonth(dayjs().startOf("month"));
+		setCurrentMonth(startOfMonth(new Date()));
 	};
 
-	const isCurrentMonth = currentMonth.isSame(dayjs(), "month");
+	const isCurrentMonth = isSameMonth(currentMonth, new Date());
 	const isMonthView = viewMode === "calendar";
 
 	return (
@@ -96,7 +102,7 @@ const CalendarView = () => {
 				<div className="flex items-center gap-2">
 					{isMonthView && (
 						<h1 className="text-xl font-semibold sm:text-2xl">
-							{currentMonth.format("MMMM YYYY")}
+							{format(currentMonth, "MMMM yyyy")}
 						</h1>
 					)}
 				</div>
@@ -154,7 +160,7 @@ const CalendarView = () => {
 
 			<MultiActivityForm
 				key={quickAddDay?.toISOString() ?? "closed"}
-				date={quickAddDay?.toDate() ?? null}
+				date={quickAddDay ?? null}
 				open={quickAddDay !== null}
 				onOpenChange={(open) => {
 					if (!open) setQuickAddDay(null);

--- a/src/components/calendar/quick-add-form.tsx
+++ b/src/components/calendar/quick-add-form.tsx
@@ -22,13 +22,13 @@ import { trpc } from "@/lib/trpc";
 import { type ActivitySchema, activitySchema } from "@/schema/activity-schema";
 import type { SupportItemListOutput } from "@/server/api/routers/support-item-router";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { Dayjs } from "dayjs";
+import { endOfDay, format, startOfDay } from "date-fns";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
 interface Props {
-	day: Dayjs | null;
+	day: Date | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onSuggestTrip?: () => void;
@@ -45,7 +45,7 @@ const QuickAddForm = ({ day, open, onOpenChange, onSuggestTrip }: Props) => {
 		resolver: zodResolver(activitySchema),
 		mode: "onBlur",
 		defaultValues: {
-			date: day ? stripTimezone(day.toDate()) : stripTimezone(new Date()),
+			date: day ? stripTimezone(day) : stripTimezone(new Date()),
 			supportItemId: "",
 			clientId: "",
 			startTime: "",
@@ -60,7 +60,7 @@ const QuickAddForm = ({ day, open, onOpenChange, onSuggestTrip }: Props) => {
 	useEffect(() => {
 		if (open && day) {
 			form.reset({
-				date: stripTimezone(day.toDate()),
+				date: stripTimezone(day),
 				supportItemId: defaultSupportItemId ?? "",
 				clientId: "",
 				startTime: "",
@@ -115,8 +115,8 @@ const QuickAddForm = ({ day, open, onOpenChange, onSuggestTrip }: Props) => {
 		const hasTimes = data.startTime && data.endTime;
 		if (hasTimes && onSuggestTrip && day) {
 			const activities = await trpcUtils.activity.byDateRange.fetch({
-				startDate: day.startOf("day").toDate(),
-				endDate: day.endOf("day").toDate()
+				startDate: startOfDay(day),
+				endDate: endOfDay(day)
 			});
 			const eligibleCount = activities.filter(
 				(a) => a.startTime && a.endTime && !a.tripId
@@ -141,7 +141,7 @@ const QuickAddForm = ({ day, open, onOpenChange, onSuggestTrip }: Props) => {
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>
-					<DialogTitle>Add Activity — {day.format("ddd D MMM")}</DialogTitle>
+					<DialogTitle>Add Activity — {format(day, "EEE d MMM")}</DialogTitle>
 				</DialogHeader>
 
 				<Form {...form}>

--- a/src/components/forms/date-picker.tsx
+++ b/src/components/forms/date-picker.tsx
@@ -2,9 +2,6 @@ import type { InputProps } from "@/components/ui/input";
 import { Input } from "@/components/ui/input";
 import { FieldValues } from "react-hook-form";
 
-import dayjs from "dayjs";
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
-
 export default function DatePicker<T extends FieldValues>({
 	...rest
 }: InputProps<T>) {

--- a/src/components/forms/time-input.tsx
+++ b/src/components/forms/time-input.tsx
@@ -2,10 +2,6 @@ import type { InputProps } from "@/components/ui/input";
 import { Input } from "@/components/ui/input";
 import { FieldValues } from "react-hook-form";
 
-import dayjs from "dayjs";
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
-
 export default function TimeInput<T extends FieldValues>({
 	rules,
 	...rest

--- a/src/components/invoices/invoice-activity-creation-form.tsx
+++ b/src/components/invoices/invoice-activity-creation-form.tsx
@@ -46,11 +46,6 @@ import {
 	useFieldArray
 } from "react-hook-form";
 
-import dayjs from "dayjs";
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/localizedFormat"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
-
 interface Props {
 	control: Control<InvoiceSchema>;
 	getValues: UseFormGetValues<InvoiceSchema>;

--- a/src/components/invoices/invoice-form.tsx
+++ b/src/components/invoices/invoice-form.tsx
@@ -17,7 +17,7 @@ import {
 	PopoverContent,
 	PopoverTrigger
 } from "@/components/ui/popover";
-import { stripTimezone } from "@/lib/date-utils";
+import { stripTimezone, utcDate } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { InvoiceSchema, invoiceSchema } from "@/schema/invoice-schema";
@@ -30,11 +30,6 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import InvoiceActivityCreationForm from "./invoice-activity-creation-form";
 import UnassignedActivities from "./unnassigned-activities";
-
-import dayjs from "dayjs";
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/localizedFormat"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
 
 interface Props {
 	onSubmit: (invoiceData: InvoiceSchema) => void;
@@ -50,7 +45,7 @@ const InvoiceForm = ({ existingInvoice, onSubmit }: Props) => {
 			...existingInvoice,
 			clientId: existingInvoice?.clientId ?? "",
 			date: existingInvoice?.date
-				? dayjs.utc(existingInvoice?.date, "YYYY-MM-DD").toDate()
+				? utcDate(existingInvoice.date)
 				: stripTimezone(new Date()),
 			invoiceNo: existingInvoice?.invoiceNo ?? "",
 			billTo: existingInvoice?.billTo ?? "",

--- a/src/components/invoices/invoice-list.tsx
+++ b/src/components/invoices/invoice-list.tsx
@@ -21,8 +21,9 @@ import { InvoiceStatus } from "@/generated/browser";
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { trpc } from "@/lib/trpc";
 import { InvoiceListOutput } from "@/server/api/routers/invoice-router";
+import { utcDate } from "@/lib/date-utils";
 import { ColumnDef } from "@tanstack/react-table";
-import dayjs from "dayjs";
+import { format } from "date-fns";
 import {
 	Copy,
 	Download,
@@ -49,7 +50,6 @@ import {
 	InputGroupAddon,
 	InputGroupInput
 } from "../ui/input-group";
-dayjs.extend(require("dayjs/plugin/utc"));
 
 interface Props {
 	clientId?: string;
@@ -214,7 +214,7 @@ export default function InvoiceList({ clientId: propClientId }: Props) {
 			header: ({ column }) => (
 				<SortingHeader column={column}>Date</SortingHeader>
 			),
-			cell: ({ row }) => <>{dayjs.utc(row.original.date).format("DD/MM/YY")}</>
+			cell: ({ row }) => <>{format(utcDate(row.original.date), "dd/MM/yy")}</>
 		},
 		{
 			accessorKey: "invoiceNo",

--- a/src/components/invoices/invoice-page.tsx
+++ b/src/components/invoices/invoice-page.tsx
@@ -15,7 +15,8 @@ import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogPanel, Transition } from "@headlessui/react";
 import { InvoiceStatus } from "@/generated/browser";
-import dayjs from "dayjs";
+import { utcDate } from "@/lib/date-utils";
+import { format } from "date-fns";
 import {
 	ChevronDown,
 	Clock,
@@ -31,8 +32,6 @@ import {
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Fragment, useState } from "react";
-
-dayjs.extend(require("dayjs/plugin/utc"));
 
 const PdfPreview = dynamic(() => import("@/components/invoices/pdf-preview"), {
 	ssr: false
@@ -270,7 +269,7 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 						</div>
 						{invoice.sentAt && (
 							<div className="text-foreground/80 flex flex-col gap-1">
-								<p>Sent on: {dayjs.utc(invoice.sentAt).format("DD/MM/YYYY")}</p>
+								<p>Sent on: {format(utcDate(invoice.sentAt), "dd/MM/yyyy")}</p>
 							</div>
 						)}
 					</div>
@@ -288,9 +287,9 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 							<div>
 								<p className="font-semibold">{version.displayInvoiceNo}</p>
 								<p className="text-foreground/60 text-sm">
-									Sent {dayjs.utc(version.sentAt).format("DD/MM/YYYY")}
+									Sent {format(utcDate(version.sentAt), "dd/MM/yyyy")}
 									{version.paidAt &&
-										` · Paid ${dayjs.utc(version.paidAt).format("DD/MM/YYYY")}`}
+										` · Paid ${format(utcDate(version.paidAt), "dd/MM/yyyy")}`}
 									{version.backfilled && " · Backfilled"}
 								</p>
 							</div>
@@ -333,7 +332,7 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 					<p className="font-semibold">Info</p>
 					<div className="flex items-center gap-4 p-2">
 						<Clock className="h-4 w-4" />
-						<p>{dayjs.utc(invoice.date).format("DD/MM/YYYY")}</p>
+						<p>{format(utcDate(invoice.date), "dd/MM/yyyy")}</p>
 					</div>
 					<Link
 						className="text-fg hover:bg-foreground/15 flex w-full items-center gap-4 rounded-md p-2 text-left"
@@ -352,7 +351,7 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 					{invoice.paidAt && (
 						<div className="flex items-center gap-4 p-2">
 							<DollarSign className="h-4 w-4" />
-							<p>Paid {dayjs.utc(invoice.paidAt).format("DD/MM/YYYY")}</p>
+							<p>Paid {format(utcDate(invoice.paidAt), "dd/MM/yyyy")}</p>
 						</div>
 					)}
 				</div>

--- a/src/components/invoices/log-payment-dialog.tsx
+++ b/src/components/invoices/log-payment-dialog.tsx
@@ -13,7 +13,8 @@ import { Input } from "@/components/ui/input";
 import { debounce } from "@/lib/generic-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import dayjs from "dayjs";
+import { utcDate } from "@/lib/date-utils";
+import { format } from "date-fns";
 import { Plus, Wallet } from "lucide-react";
 import { Fragment, useEffect, useState } from "react";
 import { toast } from "react-toastify";
@@ -108,7 +109,7 @@ const LogPaymentDialog = () => {
 						})}
 					</p>
 					<p className="text-neutral-600">
-						{dayjs.utc(invoice.date).format("DD/MM/YY")}
+						{format(utcDate(invoice.date), "dd/MM/yy")}
 					</p>
 				</div>
 			</label>

--- a/src/components/invoices/unnassigned-activities.tsx
+++ b/src/components/invoices/unnassigned-activities.tsx
@@ -3,7 +3,8 @@ import Heading from "@/components/ui/heading";
 import { cn } from "@/lib/utils";
 import { InvoiceSchema } from "@/schema/invoice-schema";
 import { ActivityListOutput } from "@/server/api/routers/activity-router";
-import dayjs from "dayjs";
+import { utcDate } from "@/lib/date-utils";
+import { format } from "date-fns";
 import { Calendar, Car, Clock } from "lucide-react";
 import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
 
@@ -64,13 +65,13 @@ const UnassignedActivities = ({ activities, getValues, setValue }: Props) => {
 								<div className="flex justify-start gap-6 text-sm md:text-sm">
 									<div className="flex items-center gap-2">
 										<Calendar className="h-4 w-4" />
-										{dayjs.utc(activity.date).format("dddd DD/MM")}
+										{format(utcDate(activity.date), "EEEE dd/MM")}
 									</div>
 									{activity.startTime && activity.endTime ? (
 										<div className="flex items-center gap-2">
 											<Clock className="h-4 w-4" />
-											{dayjs.utc(activity.startTime).format("h:mma")}-
-											{dayjs.utc(activity.endTime).format("h:mma")}
+											{format(utcDate(activity.startTime), "h:mmaaa")}-
+											{format(utcDate(activity.endTime), "h:mmaaa")}
 										</div>
 									) : (
 										<div className="flex items-center gap-2">

--- a/src/components/trips/trip-editor-modal.tsx
+++ b/src/components/trips/trip-editor-modal.tsx
@@ -19,8 +19,8 @@ import { cn } from "@/lib/utils";
 import { trpc } from "@/lib/trpc";
 import type { ActivityByDateRangeOutput } from "@/server/api/routers/activity-router";
 import type { TripRouterOutput } from "@/server/api/routers/trip-router";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
+import { utcDate } from "@/lib/date-utils";
+import { format, getHours, getMinutes } from "date-fns";
 import {
 	AlertTriangle,
 	ArrowRight,
@@ -31,8 +31,6 @@ import {
 } from "lucide-react";
 import { startTransition, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
-
-dayjs.extend(utc);
 
 type Trip = NonNullable<TripRouterOutput["getByDate"]>;
 
@@ -67,10 +65,10 @@ const getGapWarning = (
 ): string | null => {
 	if (!from.endTime || !to.startTime) return null;
 
-	const endMinutes =
-		dayjs.utc(from.endTime).hour() * 60 + dayjs.utc(from.endTime).minute();
-	const startMinutes =
-		dayjs.utc(to.startTime).hour() * 60 + dayjs.utc(to.startTime).minute();
+	const fromEnd = utcDate(from.endTime);
+	const toStart = utcDate(to.startTime);
+	const endMinutes = getHours(fromEnd) * 60 + getMinutes(fromEnd);
+	const startMinutes = getHours(toStart) * 60 + getMinutes(toStart);
 	const gapMinutes = startMinutes - endMinutes;
 
 	if (gapMinutes > 120) {
@@ -412,8 +410,15 @@ const TripEditorModal = (props: Props) => {
 													{activity.client?.name ?? "Unknown Client"}
 												</p>
 												<p className="text-muted-foreground text-xs">
-													{dayjs.utc(activity.startTime).format("H:mm")} -{" "}
-													{dayjs.utc(activity.endTime).format("H:mm")}
+													{format(
+														utcDate(activity.startTime ?? new Date(0)),
+														"H:mm"
+													)}{" "}
+													-{" "}
+													{format(
+														utcDate(activity.endTime ?? new Date(0)),
+														"H:mm"
+													)}
 												</p>
 											</div>
 											{selectedIds.has(activity.id) && (
@@ -450,8 +455,15 @@ const TripEditorModal = (props: Props) => {
 												</p>
 											</div>
 											<p className="text-muted-foreground ml-7 text-xs">
-												{dayjs.utc(activity.startTime).format("H:mm")} -{" "}
-												{dayjs.utc(activity.endTime).format("H:mm")}
+												{format(
+													utcDate(activity.startTime ?? new Date(0)),
+													"H:mm"
+												)}{" "}
+												-{" "}
+												{format(
+													utcDate(activity.endTime ?? new Date(0)),
+													"H:mm"
+												)}
 											</p>
 										</div>
 										{sortedActivities.length > 2 && (

--- a/src/lib/activity-utils.test.ts
+++ b/src/lib/activity-utils.test.ts
@@ -5,10 +5,6 @@ import {
 import { Prisma, RateType } from "@/generated/client";
 import { expect, test } from "vitest";
 
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-
 const getActivity = (
 	day: "weekday" | "saturday" | "sunday",
 	startTime: string,
@@ -24,8 +20,8 @@ const getActivity = (
 
 	return {
 		date: date,
-		startTime: dayjs.utc(`1970-01-01T${startTime}`).toDate(),
-		endTime: dayjs.utc(`1970-01-01T${endTime}`).toDate(),
+		startTime: new Date(`1970-01-01T${startTime}Z`),
+		endTime: new Date(`1970-01-01T${endTime}Z`),
 		transitDuration: new Prisma.Decimal(transitDuration),
 		transitDistance: new Prisma.Decimal(transitDistance),
 		supportItem: {
@@ -45,8 +41,8 @@ const getActivity = (
 
 const baseActivity = {
 	date: new Date("2022-01-14"),
-	startTime: dayjs.utc("1970-01-01T15:00").toDate(),
-	endTime: dayjs.utc("1970-01-01T17:00").toDate(),
+	startTime: new Date("1970-01-01T15:00Z"),
+	endTime: new Date("1970-01-01T17:00Z"),
 	transitDuration: new Prisma.Decimal(7),
 	transitDistance: new Prisma.Decimal(15),
 	itemDistance: null,
@@ -70,39 +66,39 @@ test("Should return correct rates", () => {
 	expect(getRateForActivity(activity)).toEqual(["weekday", 1]);
 
 	// 7:30pm weekday - still weekday rate (weeknight starts at 8pm)
-	activity.endTime = dayjs.utc("1970-01-01T19:30").toDate();
+	activity.endTime = new Date("1970-01-01T19:30Z");
 	expect(getRateForActivity(activity)).toEqual(["weekday", 1]);
 
 	// 7:59pm weekday - still weekday rate
-	activity.endTime = dayjs.utc("1970-01-01T19:59").toDate();
+	activity.endTime = new Date("1970-01-01T19:59Z");
 	expect(getRateForActivity(activity)).toEqual(["weekday", 1]);
 
 	// After 8pm - weeknight
-	activity.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activity.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activity)).toEqual(["weeknight", 2]);
 
 	// At 8pm - weeknight
-	activity.endTime = dayjs.utc("1970-01-01T20:00").toDate();
+	activity.endTime = new Date("1970-01-01T20:00Z");
 	expect(getRateForActivity(activity)).toEqual(["weeknight", 2]);
 
 	// Saturday - saturday
 	activity.date = new Date("2022-01-15");
-	activity.endTime = dayjs.utc("1970-01-01T15:10").toDate();
+	activity.endTime = new Date("1970-01-01T15:10Z");
 	expect(getRateForActivity(activity)).toEqual(["saturday", 3]);
 
 	// Saturday night - saturday
 	activity.date = new Date("2022-01-15");
-	activity.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activity.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activity)).toEqual(["saturday", 3]);
 
 	// Sunday - sunday
 	activity.date = new Date("2022-01-16");
-	activity.endTime = dayjs.utc("1970-01-01T15:10").toDate();
+	activity.endTime = new Date("1970-01-01T15:10Z");
 	expect(getRateForActivity(activity)).toEqual(["sunday", 4]);
 
 	// Sunday night - sunday
 	activity.date = new Date("2022-01-16");
-	activity.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activity.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activity)).toEqual(["sunday", 4]);
 });
 
@@ -126,31 +122,31 @@ test("Should return correct rates", () => {
 	expect(getRateForActivity(activityWithRates)).toEqual(["weekday", 5]);
 
 	// After 8pm - weeknight
-	activityWithRates.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["weeknight", 6]);
 
 	// At 8pm - weeknight
-	activityWithRates.endTime = dayjs.utc("1970-01-01T20:00").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T20:00Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["weeknight", 6]);
 
 	// Saturday - saturday
 	activityWithRates.date = new Date("2022-01-15");
-	activityWithRates.endTime = dayjs.utc("1970-01-01T15:10").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T15:10Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["saturday", 7]);
 
 	// Saturday night - saturday
 	activityWithRates.date = new Date("2022-01-15");
-	activityWithRates.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["saturday", 7]);
 
 	// Sunday - sunday
 	activityWithRates.date = new Date("2022-01-16");
-	activityWithRates.endTime = dayjs.utc("1970-01-01T15:10").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T15:10Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["sunday", 8]);
 
 	// Sunday night - sunday
 	activityWithRates.date = new Date("2022-01-16");
-	activityWithRates.endTime = dayjs.utc("1970-01-01T20:10").toDate();
+	activityWithRates.endTime = new Date("1970-01-01T20:10Z");
 	expect(getRateForActivity(activityWithRates)).toEqual(["sunday", 8]);
 });
 

--- a/src/lib/billing-lines.ts
+++ b/src/lib/billing-lines.ts
@@ -9,16 +9,14 @@ import type {
 	SupportItemRates
 } from "@/generated/client";
 import type { UnitPriceSuffix } from "@/schema/invoice-version-schema";
-import { formatDuration, getDuration } from "./date-utils";
+import { formatDuration, getDuration, utcDate } from "./date-utils";
 import { floorToCent, round } from "./generic-utils";
 import {
 	getActivityBasedTransportCode,
 	getNonLabourTravelCode
 } from "./support-item-utils";
 
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
+import { format, getDay, getHours } from "date-fns";
 
 interface TransportItem {
 	type: ActivityTransportType;
@@ -107,7 +105,7 @@ export const getRateForActivity = (
 ): [code: string, rate: number] => {
 	// Saturday
 	if (
-		dayjs.utc(activity.date).day() === 6 &&
+		getDay(utcDate(activity.date)) === 6 &&
 		activity.supportItem.saturdayCode?.length
 	) {
 		const rate = getRateForDay(
@@ -123,7 +121,7 @@ export const getRateForActivity = (
 
 	// Sunday
 	if (
-		dayjs.utc(activity.date).day() === 0 &&
+		getDay(utcDate(activity.date)) === 0 &&
 		activity.supportItem.sundayCode?.length
 	) {
 		const rate = getRateForDay(
@@ -139,7 +137,7 @@ export const getRateForActivity = (
 
 	if (
 		activity.endTime &&
-		dayjs.utc(activity.endTime).hour() >= 20 &&
+		getHours(utcDate(activity.endTime)) >= 20 &&
 		activity.supportItem.weeknightCode?.length &&
 		activity.supportItem.weeknightRate
 	) {
@@ -419,11 +417,12 @@ export function lineDetailsText(
 	switch (line.kind) {
 		case "SUPPORT": {
 			if (line.unit === "HOUR") {
-				return `${dayjs
-					.utc(activity.startTime ?? undefined)
-					.format("HH:mm")}-${dayjs
-					.utc(activity.endTime ?? undefined)
-					.format("HH:mm")} (${formatDuration(line.quantity)})`;
+				const start = format(
+					utcDate(activity.startTime ?? new Date(0)),
+					"HH:mm"
+				);
+				const end = format(utcDate(activity.endTime ?? new Date(0)), "HH:mm");
+				return `${start}-${end} (${formatDuration(line.quantity)})`;
 			}
 
 			return `${line.quantity} km`;

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -6,12 +6,9 @@ import {
 } from "@/lib/date-utils";
 
 import { TZDate } from "@date-fns/tz";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import { expect, test } from "vitest";
-dayjs.extend(utc);
 
-const dateFromTime = (time: string) => dayjs.utc(`1970-01-01T${time}`).toDate();
+const dateFromTime = (time: string) => new Date(`1970-01-01T${time}Z`);
 
 test("Should get duration", () => {
 	expect(getDuration(dateFromTime("12:00"), dateFromTime("13:00"))).toEqual(1);

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,22 +1,43 @@
 import { round } from "./generic-utils";
 
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(customParseFormat);
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import { TZDate, tz } from "@date-fns/tz";
+import {
+	differenceInMinutes,
+	format,
+	getHours,
+	getMinutes,
+	parse,
+	setDate,
+	setHours,
+	setMinutes,
+	setMonth
+} from "date-fns";
+
+/**
+ * A UTC-anchored view of an instant - the single place the `"UTC"` timezone
+ * lives. Use it to read wall-clock fields (`getHours`, `getDay`, ...) or to
+ * `format`/`toISOString` an instant as UTC, regardless of the viewer's zone.
+ */
+export const utcDate = (value: Date | string | number): TZDate =>
+	new TZDate(new Date(value), "UTC");
+
+/**
+ * Parses an `HH:mm` wall-clock string into a UTC-anchored Date on the epoch
+ * day (1970-01-01). The date portion is irrelevant to callers - only the
+ * time-of-day is ever read back - so the epoch reference keeps it deterministic.
+ * A missing time yields an Invalid Date, matching the prior dayjs behaviour.
+ */
+export const parseUtcTime = (time: string | undefined): Date =>
+	time === undefined
+		? new Date(NaN)
+		: parse(time, "HH:mm", new TZDate(0, "UTC"), { in: tz("UTC") });
 
 export function getDuration(startTime: Date, endTime: Date): number {
-	const startDate = dayjs(startTime);
-	const endDate = dayjs(endTime);
-
-	const diffInMinutes = endDate.diff(startDate, "minutes");
+	const diffInMinutes = differenceInMinutes(endTime, startTime);
 
 	if (diffInMinutes < 0) {
 		throw new Error(
-			`getDuration: endTime ${endDate.toISOString()} precedes startTime ${startDate.toISOString()}`
+			`getDuration: endTime ${endTime.toISOString()} precedes startTime ${startTime.toISOString()}`
 		);
 	}
 
@@ -34,14 +55,15 @@ export function formatActivityDuration(startTime: Date, endTime: Date): string {
 }
 
 export const formatDuration = (duration: number) => {
-	const hourItem = dayjs()
-		.set("hours", duration)
-		.set("minutes", round((duration % 1) * 60, 0));
+	const hourItem = setMinutes(
+		setHours(new Date(), duration),
+		round((duration % 1) * 60, 0)
+	);
 
 	let durationString = "";
 
-	const hours = hourItem.get("hours");
-	const minutes = hourItem.get("minutes");
+	const hours = getHours(hourItem);
+	const minutes = getMinutes(hourItem);
 	if (hours > 0) durationString += `${hours} hour${hours === 1 ? "" : "s"}`;
 
 	if (minutes > 0)
@@ -54,17 +76,20 @@ export const formatDuration = (duration: number) => {
 
 // TODO: Implement dynamic holidays
 // (e.g. Easter occurs on the Sunday after the first full moon following the vernal equinox)
+const holiday = (day: number, month: number) =>
+	format(setMonth(setDate(new Date(), day), month), "dd/MM/yyyy");
+
 const HOLIDAYS = new Set([
-	dayjs().date(1).month(0).format("DD/MM/YYYY"),
-	dayjs().date(26).month(0).format("DD/MM/YYYY"),
-	dayjs().date(25).month(3).format("DD/MM/YYYY"),
-	dayjs().date(24).month(11).format("DD/MM/YYYY"),
-	dayjs().date(25).month(11).format("DD/MM/YYYY"),
-	dayjs().date(26).month(11).format("DD/MM/YYYY")
+	holiday(1, 0),
+	holiday(26, 0),
+	holiday(25, 3),
+	holiday(24, 11),
+	holiday(25, 11),
+	holiday(26, 11)
 ]);
 
 export function isHoliday(date: Date | string) {
-	return HOLIDAYS.has(dayjs(date).format("DD/MM/YYYY"));
+	return HOLIDAYS.has(format(new Date(date), "dd/MM/yyyy"));
 }
 
 /**

--- a/src/lib/invoice-utils.ts
+++ b/src/lib/invoice-utils.ts
@@ -1,11 +1,4 @@
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
 import { round } from "./generic-utils";
-dayjs.extend(customParseFormat);
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 const getNumber = (invoiceNo: string): number | undefined => {
 	const matches = invoiceNo.match(/\d+$/);

--- a/src/lib/invoice-version.ts
+++ b/src/lib/invoice-version.ts
@@ -12,9 +12,7 @@ import { round } from "./generic-utils";
 import { displayInvoiceNo } from "./invoice-utils";
 import type { InvoicePdfData } from "./pdf-generation";
 
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
+import { utcDate } from "./date-utils";
 
 const groupDigits = (value: string, separator: string) =>
 	value.replaceAll(/\B(?=(\d{3})+(?!\d))/g, separator);
@@ -72,7 +70,7 @@ export function buildInvoiceVersionContent(
 					kind: line.kind,
 					description: line.description,
 					supportItemCode: line.supportItemCode,
-					serviceDate: dayjs.utc(line.serviceDate).toISOString(),
+					serviceDate: utcDate(line.serviceDate).toISOString(),
 					quantity: line.quantity,
 					unit: line.unit,
 					unitPrice: line.unitPrice,
@@ -95,7 +93,7 @@ export function buildInvoiceVersionContent(
 		header: {
 			invoiceNo: invoice.invoiceNo,
 			displayInvoiceNo: displayInvoiceNo(invoice.invoiceNo, versionNumber),
-			date: dayjs.utc(invoice.date).toISOString(),
+			date: utcDate(invoice.date).toISOString(),
 			participantName: invoice.client?.name ?? "",
 			...(invoice.client?.number
 				? { participantNumber: invoice.client.number }

--- a/src/lib/pdf-generation.ts
+++ b/src/lib/pdf-generation.ts
@@ -16,11 +16,8 @@ import {
 	type UnitPriceSuffix
 } from "@/schema/invoice-version-schema";
 
-import dayjs from "dayjs";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import { utcDate } from "./date-utils";
+import { format } from "date-fns";
 
 // import "@/fonts/Inter-normal";
 
@@ -102,7 +99,7 @@ interface PdfLine {
 
 /** The Details-column cell for a line, plus its Unit Price column. */
 const formatPdfLine = (line: PdfLine): string[] => {
-	const dateCell = `${dayjs.utc(line.serviceDate).format("DD/MM/YY")}\n`;
+	const dateCell = `${format(utcDate(line.serviceDate), "dd/MM/yy")}\n`;
 	const descriptionCell = `${line.description}\n${line.supportItemCode}\n`;
 	const totalCell = `$${line.total.toFixed(2)}\n`;
 	const detailsCell = `${line.detailsText}\n`;
@@ -150,7 +147,7 @@ const renderFromRenderable = (
 	// Write details at top of page
 	const invoiceDetails: string[] = [
 		`Invoice Number: ${renderable.invoiceNoLabel}`,
-		`Invoice Date: ${dayjs(renderable.date).format("DD/MM/YY")}`,
+		`Invoice Date: ${format(new Date(renderable.date), "dd/MM/yy")}`,
 		`Participant Name: ${renderable.participantName}`
 	];
 	if (renderable.participantNumber)

--- a/src/lib/trip-utils.test.ts
+++ b/src/lib/trip-utils.test.ts
@@ -10,10 +10,6 @@ import {
 import { Prisma } from "@/generated/client";
 import { expect, test } from "vitest";
 
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
-
 const getTripActivity = (
 	id: string,
 	startTime: string | null,
@@ -23,7 +19,7 @@ const getTripActivity = (
 	}: { distanceToClient?: number; travelTimeToClient?: number } = {}
 ): TripActivity => ({
 	id,
-	startTime: startTime ? dayjs.utc(`1970-01-01T${startTime}`).toDate() : null,
+	startTime: startTime ? new Date(`1970-01-01T${startTime}Z`) : null,
 	endTime: null,
 	transitDistance: null,
 	transitDuration: null,
@@ -196,8 +192,8 @@ test("Prisma.Decimal distance/duration inputs produce plain-number outputs", () 
 });
 
 test("sortActivitiesByTime: sorts by startTime, null startTimes last", () => {
-	const a = { startTime: dayjs.utc("1970-01-01T10:00").toDate() };
-	const b = { startTime: dayjs.utc("1970-01-01T09:00").toDate() };
+	const a = { startTime: new Date("1970-01-01T10:00Z") };
+	const b = { startTime: new Date("1970-01-01T09:00Z") };
 	const c = { startTime: null };
 
 	expect(sortActivitiesByTime([a, b, c])).toEqual([b, a, c]);

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -9,13 +9,12 @@ import { authedProcedure, router } from "@/server/api/trpc";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
 import { z } from "zod";
 
-import dayjs from "dayjs";
+import { parseUtcTime, utcDate } from "@/lib/date-utils";
+import { format } from "date-fns";
 import {
 	DEFAULT_LIST_LIMIT,
 	DEFAULT_UNBILLED_PAGE_SIZE
 } from "./router.constants";
-dayjs.extend(require("dayjs/plugin/utc"));
-dayjs.extend(require("dayjs/plugin/customParseFormat"));
 
 const defaultActivitySelect = {
 	id: true,
@@ -321,10 +320,10 @@ export const activityRouter = router({
 			const { transportItems, ...activityData } = inputActivity;
 
 			const startTime = activityData.startTime
-				? dayjs.utc(activityData.startTime, "HH:mm").toDate()
+				? parseUtcTime(activityData.startTime)
 				: undefined;
 			const endTime = activityData.endTime
-				? dayjs.utc(activityData.endTime, "HH:mm").toDate()
+				? parseUtcTime(activityData.endTime)
 				: undefined;
 
 			const conflicting = await checkActivityOverlap(ctx.prisma, {
@@ -385,10 +384,10 @@ export const activityRouter = router({
 			const { transportItems, ...activityData } = input.activity;
 
 			const startTime = activityData.startTime
-				? dayjs.utc(activityData.startTime, "HH:mm").toDate()
+				? parseUtcTime(activityData.startTime)
 				: undefined;
 			const endTime = activityData.endTime
-				? dayjs.utc(activityData.endTime, "HH:mm").toDate()
+				? parseUtcTime(activityData.endTime)
 				: undefined;
 
 			const conflicting = await checkActivityOverlap(ctx.prisma, {
@@ -520,10 +519,10 @@ export const activityRouter = router({
 				return {
 					...activityData,
 					startTime: activityData.startTime
-						? dayjs.utc(activityData.startTime, "HH:mm").toDate()
+						? parseUtcTime(activityData.startTime)
 						: undefined,
 					endTime: activityData.endTime
-						? dayjs.utc(activityData.endTime, "HH:mm").toDate()
+						? parseUtcTime(activityData.endTime)
 						: undefined,
 					transportItems
 				};
@@ -586,8 +585,8 @@ export const activityRouter = router({
 					if (!prevActivity.endTime || !activity.startTime) return false;
 					// Check if end time of previous equals start time of current
 					return (
-						dayjs.utc(prevActivity.endTime).format("HH:mm") ===
-						dayjs.utc(activity.startTime).format("HH:mm")
+						format(utcDate(prevActivity.endTime), "HH:mm") ===
+						format(utcDate(activity.startTime), "HH:mm")
 					);
 				});
 

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -20,8 +20,9 @@ import {
 	PrismaClient,
 	type Prisma
 } from "@/generated/client";
+import { parseUtcTime, utcDate } from "@/lib/date-utils";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
-import dayjs from "dayjs";
+import { format } from "date-fns";
 import { z } from "zod";
 import { DEFAULT_LIST_LIMIT } from "./router.constants";
 
@@ -95,7 +96,7 @@ export function parseInvoice<
 
 	return {
 		...rest,
-		date: dayjs(invoice.date).format("YYYY-MM-DD"),
+		date: format(new Date(invoice.date ?? Date.now()), "yyyy-MM-dd"),
 		...(versions && {
 			versions: versions
 				.slice()
@@ -118,8 +119,8 @@ const generateNestedWriteForActivities = (
 			return activities.map((activity) => ({
 				...activity,
 				date: activity.date,
-				startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
-				endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
+				startTime: parseUtcTime(activity.startTime),
+				endTime: parseUtcTime(activity.endTime),
 				clientId: client.id,
 				transitDistance: client.distanceToClient ?? undefined,
 				transitDuration: client.travelTimeToClient ?? undefined,
@@ -147,8 +148,8 @@ const generateNestedWriteForGroupActivities = (
 					...activity,
 					supportItemId,
 					date: activity.date,
-					startTime: dayjs.utc(activity.startTime, "HH:mm").toDate(),
-					endTime: dayjs.utc(activity.endTime, "HH:mm").toDate(),
+					startTime: parseUtcTime(activity.startTime),
+					endTime: parseUtcTime(activity.endTime),
 					clientId: groupClientId,
 					transitDistance: client?.distanceToClient ?? undefined,
 					transitDuration: client?.travelTimeToClient ?? undefined,
@@ -582,9 +583,7 @@ export const invoiceRouter = router({
 						invoiceNo: inputInvoice.invoiceNo,
 						billTo: inputInvoice.billTo,
 						clientId: inputInvoice.clientId,
-						date: inputInvoice.date
-							? dayjs.utc(inputInvoice.date).toDate()
-							: new Date(),
+						date: inputInvoice.date ? utcDate(inputInvoice.date) : new Date(),
 						activities: {
 							connect: inputInvoice.activityIds?.map((id) => ({ id })),
 							createMany: inputInvoice.activitiesToCreate


### PR DESCRIPTION
Closes #409.

Consolidates the codebase on **date-fns** (+ `@date-fns/tz` for UTC) and removes **dayjs**. This eliminates the shipped duplicate date library and the fragile per-file `dayjs.extend(require("dayjs/plugin/..."))` registration pattern (17 sites across 9 files, with plugin sets drifting per file).

## What changed
- Migrated every `dayjs`/`dayjs.utc` usage across `src`, `prisma/seed.ts`, and `e2e/` to date-fns.
- Deleted all `dayjs.extend(...)` / `dayjs/plugin` lines, including several files that imported dayjs but never used it (dead `timezone`/`customParseFormat`/`localizedFormat` registrations).
- Removed `dayjs` from `package.json`; regenerated the lockfile.
- Added an ESLint `no-restricted-imports` rule banning `dayjs` (and `dayjs/*`) so it can't creep back.

## UTC handling
All `.utc()` sites were pure-UTC (times anchored to the UTC epoch so wall-clock renders identically regardless of viewer timezone). Introduced two helpers in `src/lib/date-utils.ts` as the single home for the `"UTC"` timezone:
- `utcDate(value)` - a `TZDate` view of an instant in UTC, for reading wall-clock fields or formatting/serialising as UTC.
- `parseUtcTime(time)` - parses an `HH:mm` string to a UTC-anchored `Date` on the epoch day.

## Format tokens
All dayjs format strings were remapped to Unicode LDML (they are **not** dayjs-compatible): `DD/MM/YYYY`→`dd/MM/yyyy`, `ddd`→`EEE`, `dddd`→`EEEE`, `D`→`d`, `h:mma`→`h:mmaaa`, etc. The four pre-existing date-fns `format` sites were already correct and are unchanged. PDF snapshot tests confirm rendered output is byte-identical.

## Deviation from the issue's mapping table
The issue suggested `new TZDate("1970-01-01T20:10", "UTC")` for `dayjs.utc("1970-01-01T20:10").toDate()`. This is incorrect for **naive datetime strings** - `TZDate` parses them as local, not UTC. Those strings only appear in test fixtures, which now use `new Date("...Z")`; `HH:mm` parsing goes through `parseUtcTime` (date-fns `parse` with `{ in: tz("UTC") }`). Date objects and date-only strings wrap correctly via `utcDate`.

## Out of scope (unchanged)
No behavioural changes to date logic (`getDuration`, rate boundaries, `stripTimezone`); date-picker components untouched.

## Verification
- `tsc --noEmit`: clean
- `eslint .`: 0 errors (dayjs ban active; only pre-existing warnings)
- Full unit suite: 150/150 pass
- PDF snapshot render tests: unchanged
