### PR TITLE
test: pin cursor + Decimal wire shape for activity.list and supportItem.list

### DIFF
--- a/src/server/api/routers/activity-router.integration.test.ts
+++ b/src/server/api/routers/activity-router.integration.test.ts
@@ -1,0 +1,108 @@
+import { Prisma } from "@/generated/client";
+import prisma from "@/server/prisma";
+import superjson from "superjson";
+import { beforeEach, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "../test/harness";
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+async function createSupportItem(ownerId: string) {
+	return prisma.supportItem.create({
+		data: {
+			description: "Standard Support",
+			weekdayCode: "01_001_0125_6_1",
+			weekdayRate: 100,
+			ownerId
+		}
+	});
+}
+
+// These are characterization tests: they pin the wire shape `activity.list`
+// returns today (cursor contract + Decimal serialization) so the better-auth
+// migration (#418), which reworks context/session, can't silently drift it.
+
+test("activity.list cursor advances across pages without overlap or gaps", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const supportItem = await createSupportItem(user.id);
+
+	// Three activities on distinct dates; list orders date desc, so the stable
+	// order is 03, 02, 01.
+	const byDate: Record<string, string> = {};
+	for (const day of ["2024-01-01", "2024-01-02", "2024-01-03"]) {
+		const created = await caller.activity.add({
+			activity: {
+				clientId: client.id,
+				supportItemId: supportItem.id,
+				date: new Date(day),
+				startTime: "09:00",
+				endTime: "10:00",
+				itemDistance: 0
+			}
+		});
+		byDate[day] = created.id;
+	}
+	const expectedOrder = [
+		byDate["2024-01-03"],
+		byDate["2024-01-02"],
+		byDate["2024-01-01"]
+	];
+
+	const page1 = await caller.activity.list({ limit: 2 });
+	expect(page1.activities).toHaveLength(2);
+	expect(page1.nextCursor).toBeTypeOf("string");
+
+	const page2 = await caller.activity.list({
+		limit: 2,
+		cursor: page1.nextCursor
+	});
+	expect(page2.activities).toHaveLength(1);
+	expect(page2.nextCursor).toBeUndefined();
+
+	// The two pages, concatenated, must equal the full seeded set in order: no
+	// overlap (a repeated row would break the equality) and no gaps (a dropped
+	// row would too). Oracle is the known seeding order, not another list() call.
+	const ids = [...page1.activities, ...page2.activities].map((a) => a.id);
+	expect(ids).toEqual(expectedOrder);
+});
+
+test("activity.list serializes Decimal fields in the current on-the-wire shape", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const supportItem = await createSupportItem(user.id);
+
+	await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0,
+			transitDistance: "12.5"
+		}
+	});
+
+	const { activities } = await caller.activity.list({ limit: 10 });
+	const [activity] = activities;
+
+	// The caller returns a Prisma.Decimal instance...
+	expect(activity.transitDistance).toBeInstanceOf(Prisma.Decimal);
+	expect(activity.transitDistance?.toString()).toBe("12.5");
+
+	// ...and superjson.stringify - exactly what the tRPC transformer puts on the
+	// wire - renders the row's Decimal as a plain JSON string with no type tag,
+	// unlike the Date fields beside it, which carry a `["Date"]` tag in
+	// meta.values. This pins the on-the-wire shape of the row; a regression that
+	// boxed or re-typed the Decimal breaks here.
+	const wire = JSON.parse(superjson.stringify(activity));
+	expect(wire.json.transitDistance).toBe("12.5");
+	expect(wire.meta?.values ?? {}).not.toHaveProperty("transitDistance");
+	expect(wire.meta?.values).toHaveProperty("date");
+});

--- a/src/server/api/routers/support-item-router.integration.test.ts
+++ b/src/server/api/routers/support-item-router.integration.test.ts
@@ -1,4 +1,6 @@
+import { Prisma } from "@/generated/client";
 import prisma from "@/server/prisma";
+import superjson from "superjson";
 import { beforeEach, expect, test } from "vitest";
 import { callerFor, createTestUser, resetDb } from "../test/harness";
 
@@ -142,4 +144,71 @@ test("a client's custom rate drives the invoice total over the support item defa
 
 	// 1 hour × custom 200/hr = 200, not the item's default 100.
 	expect(invoices[0].versions![0].total).toBe(200);
+});
+
+// These are characterization tests: they pin the wire shape `supportItem.list`
+// returns today (cursor contract + Decimal serialization) so the better-auth
+// migration (#418), which reworks context/session, can't silently drift it.
+
+test("supportItem.list cursor advances across pages without overlap or gaps", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	// Distinct createdAt values give the createdAt-desc list a stable order
+	// (item-3, item-2, item-1) so the cursor round-trip is deterministic.
+	const idByOrder: string[] = [];
+	for (let i = 1; i <= 3; i++) {
+		const created = await prisma.supportItem.create({
+			data: {
+				description: `Item ${i}`,
+				weekdayCode: `01_001_0125_6_${i}`,
+				weekdayRate: 100,
+				ownerId: user.id,
+				createdAt: new Date(`2024-01-0${i}T00:00:00.000Z`)
+			}
+		});
+		idByOrder.push(created.id);
+	}
+	// createdAt desc => newest (item-3) first.
+	const expectedOrder = [...idByOrder].reverse();
+
+	const page1 = await caller.supportItem.list({ limit: 2 });
+	expect(page1.supportItems).toHaveLength(2);
+	expect(page1.nextCursor).toBeTypeOf("string");
+
+	const page2 = await caller.supportItem.list({
+		limit: 2,
+		cursor: page1.nextCursor
+	});
+	expect(page2.supportItems).toHaveLength(1);
+	expect(page2.nextCursor).toBeUndefined();
+
+	// The two pages, concatenated, must equal the full seeded set in order: no
+	// overlap (a repeated row would break the equality) and no gaps (a dropped
+	// row would too). Oracle is the known seeding order, not another list() call.
+	const ids = [...page1.supportItems, ...page2.supportItems].map((s) => s.id);
+	expect(ids).toEqual(expectedOrder);
+});
+
+test("supportItem.list serializes Decimal fields in the current on-the-wire shape", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	// A fractional rate so the assertion pins Decimal (not integer) wire shape.
+	await createSupportItem(user.id, 100.5);
+
+	const { supportItems } = await caller.supportItem.list({ limit: 10 });
+	const [supportItem] = supportItems;
+
+	// The caller returns a Prisma.Decimal instance...
+	expect(supportItem.weekdayRate).toBeInstanceOf(Prisma.Decimal);
+	expect(supportItem.weekdayRate.toString()).toBe("100.5");
+
+	// ...and superjson.stringify - exactly what the tRPC transformer puts on the
+	// wire - renders the row's Decimal as a plain JSON string with no type tag
+	// in meta.values. This pins the on-the-wire shape of the row; a regression
+	// that boxed or re-typed the Decimal breaks here.
+	const wire = JSON.parse(superjson.stringify(supportItem));
+	expect(wire.json.weekdayRate).toBe("100.5");
+	expect(wire.meta?.values ?? {}).not.toHaveProperty("weekdayRate");
 });


### PR DESCRIPTION
Closes #465. Pre-work for the better-auth migration (#418): pins the wire contract of the two cursor-paginated list endpoints so a serialization regression can't slip through unnoticed.

## What

Adds integration tests (no production changes to routers or `paginate()`) for `activity.list` and `supportItem.list`:

- **Cursor contract** - seeds three rows to force two pages, asserts the first page returns a `nextCursor`, feeds it to the next call, and checks the concatenated pages equal the full seeded set **in known seeding order** (catches overlap, gaps, and ordering drift; the oracle is the seeding order, not a second `list()` call).
- **Decimal serialization shape** - characterizes today's on-the-wire representation by running the returned row through `superjson.stringify` (exactly what the tRPC transformer transmits) and asserting the `Decimal` field rides the wire as a plain JSON string with **no** `meta.values` type tag - unlike the `Date` fields beside it. A regression that boxed or re-typed the Decimal fails here.

## Notes

- New file: `activity-router.integration.test.ts`; two tests appended to the existing `support-item-router.integration.test.ts`.
- Modelled on `client-router.integration.test.ts` (#408).
- Fractional rate (`100.5` / `12.5`) so the assertion distinguishes Decimal from a plain number.

## Testing

- `npm run test:integration` for both files - 8 passing
- `npm run type-check` clean, eslint clean