### PR TITLE
test: e2e auth seam - authenticateAsTestUser() + parameterized Playwright webServer (#466)

### DIFF
--- a/e2e/setup/global.setup.ts
+++ b/e2e/setup/global.setup.ts
@@ -1,8 +1,7 @@
 import "dotenv/config";
 import prisma from "@/server/prisma";
 import { FullConfig, chromium } from "@playwright/test";
-import { addMonths, getUnixTime } from "date-fns";
-import { testUser } from "../test-utils";
+import { authenticateAsTestUser, testUser } from "../test-utils";
 
 /**
  * `InvoiceVersion.invoiceId` is `onDelete: Restrict` (docs/adr/0004) — a
@@ -33,19 +32,8 @@ async function globalSetup(config: FullConfig) {
 
 	const browser = await chromium.launch();
 	const page = await browser.newPage();
-	await page.goto(baseURL!);
 
-	await page.context().addCookies([
-		{
-			name: "next-auth.session-token",
-			value: testUser.sessions.create.sessionToken,
-			domain: "localhost",
-			path: "/",
-			httpOnly: true,
-			sameSite: "Lax",
-			expires: getUnixTime(addMonths(new Date(), 1))
-		}
-	]);
+	await authenticateAsTestUser(page, baseURL!);
 
 	await page.context().storageState({ path: storageState as string });
 

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -2,7 +2,7 @@ import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import prisma from "@/server/prisma";
 import { Page } from "@playwright/test";
 import { randomUUID } from "crypto";
-import { addMonths } from "date-fns";
+import { addMonths, getUnixTime } from "date-fns";
 import { randomClient } from "./random/random-client";
 import { randomSupportItem } from "./random/random-support-item";
 
@@ -34,6 +34,30 @@ export const testUser = {
 		}
 	}
 };
+
+/**
+ * Establishes an authenticated session for `testUser` on `page`.
+ *
+ * Today this injects a raw next-auth `session-token` cookie (the bypass the
+ * app relied on before better-auth). #418 swaps the body for a real password
+ * sign-in; keeping session establishment behind this single helper contains
+ * that change to here rather than every test's setup.
+ */
+export async function authenticateAsTestUser(page: Page, baseURL: string) {
+	await page.goto(baseURL);
+
+	await page.context().addCookies([
+		{
+			name: "next-auth.session-token",
+			value: testUser.sessions.create.sessionToken,
+			domain: "localhost",
+			path: "/",
+			httpOnly: true,
+			sameSite: "Lax",
+			expires: getUnixTime(addMonths(new Date(), 1))
+		}
+	]);
+}
 
 export async function waitForAlert(page: Page, text: string) {
 	return await page

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,14 @@ export default defineConfig({
 		// CI runs against a production build: `next dev`'s on-demand route
 		// compilation races with CI's limited CPU/network and intermittently
 		// stalls navigations past test timeouts.
-		command: process.env.CI ? "pnpm start" : "pnpm dev:next",
+		//
+		// E2E_WEB_SERVER_COMMAND overrides the command so the better-auth
+		// migration (#418) and framework swap (#419) can point Playwright at a
+		// different server without editing this file; the defaults keep existing
+		// local and CI runs unchanged.
+		command:
+			process.env.E2E_WEB_SERVER_COMMAND ??
+			(process.env.CI ? "pnpm start" : "pnpm dev:next"),
 		url: "http://localhost:3000",
 		reuseExistingServer: !process.env.CI
 	}


### PR DESCRIPTION
Closes #466. Pre-work for the better-auth migration (#418) and framework swap (#419).

## What

- **Extracted `authenticateAsTestUser(page, baseURL)`** into `e2e/test-utils.ts`, moving the next-auth session-cookie injection out of `e2e/setup/global.setup.ts`. Behavior is identical (still the same next-auth cookie) - a pure extraction so #418 can swap the helper body for a real password sign-in without touching every test's setup.
- **Parameterized Playwright's `webServer.command`** via `E2E_WEB_SERVER_COMMAND`, falling back to the existing defaults (`pnpm start` on CI, `pnpm dev:next` locally). #418/#419 can now point Playwright at a different server without editing `playwright.config.ts`.

## Out of scope

The actual better-auth sign-in flow (#418) and the framework swap (#419).

## Verification

- `tsc --noEmit`, eslint, prettier: pass (pre-commit hooks).
- Unit suite: 180 passed.
- e2e suite: 20 passed against a production build, invoked via `E2E_WEB_SERVER_COMMAND="pnpm start"` - exercising both the extracted helper (`global.setup.ts` -> `authenticateAsTestUser`) and the new env var.
