### PR TITLE
fix: address code-review findings on Log promotion, per-Client sections, and capture UI

### DIFF
--- a/e2e/log.test.ts
+++ b/e2e/log.test.ts
@@ -1,8 +1,20 @@
 import prisma from "@/server/prisma";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { randomUUID } from "crypto";
 import { addMonths, format, getUnixTime, subDays } from "date-fns";
 import { createDefaultSupportItem, createRandomClient } from "./test-utils";
+
+/** A Client's section of the Log, located by its heading. */
+const logSection = (page: Page, clientName: string) =>
+	page
+		.locator("[data-slot=log-client-section]")
+		.filter({ has: page.getByRole("heading", { name: clientName }) });
+
+/** The stack of days waiting to promote, which summarises Sessions too. */
+const promoteStack = (page: Page) =>
+	page.locator("section").filter({
+		has: page.getByRole("heading", { name: "Waiting to promote" })
+	});
 
 // The Log is per-Provider global state: an Open Session puts a banner on
 // every dashboard screen, and only one can be open at a time. Running these
@@ -64,7 +76,7 @@ test("Captures a day of sessions and promotes it to Activities and a Trip", asyn
 	await page.goto("/dashboard/log");
 
 	// Start the day with client A.
-	await page.getByRole("button", { name: "Start a session" }).click();
+	await page.getByRole("button", { name: "Start a Session" }).click();
 	await page.getByRole("checkbox", { name: clientA.name }).click();
 	await page.getByLabel("Started at").fill("09:00");
 	await page.getByRole("button", { name: "Start", exact: true }).click();
@@ -77,29 +89,37 @@ test("Captures a day of sessions and promotes it to Activities and a Trip", asyn
 	await expect(page.getByText("8 km logged")).toBeVisible();
 
 	// End for A, with more clients to come.
-	await page.getByRole("button", { name: "End session" }).click();
+	await page.getByRole("button", { name: "End Session" }).click();
 	await page.getByLabel("Finished at").fill("10:00");
 	await page.getByRole("button", { name: "More clients to come" }).click();
 
-	// Starting the next client captures the drive between them: the gap
-	// (10:00 → 10:20) pre-fills the travel duration.
-	await page.getByRole("button", { name: "Start a session" }).click();
+	// "More clients to come" chains straight into the Start flow - no extra
+	// navigation - and starting the next client captures the drive between
+	// them: the gap (10:00 → 10:20) pre-fills the travel duration.
+	await expect(
+		page.getByRole("heading", { name: "Start a Session" })
+	).toBeVisible();
 	await page.getByRole("checkbox", { name: clientB.name }).click();
 	await page.getByLabel("Started at").fill("10:20");
 	await page.getByRole("button", { name: "Start", exact: true }).click();
 
 	await expect(page.getByText("How did you get here?")).toBeVisible();
+	// The question can only be answered, never dismissed - a skipped gap
+	// would silently bill no travel.
+	await page.getByRole("dialog").press("Escape");
+	await expect(page.getByText("How did you get here?")).toBeVisible();
+	await expect(page.getByRole("button", { name: "Close" })).toHaveCount(0);
 	await expect(page.getByLabel("Took (min)")).toHaveValue("20");
 	await page.getByLabel("Drove (km)").fill("12");
 	await page.getByRole("button", { name: "Log the drive" }).click();
 
 	// Done for the day.
-	await page.getByRole("button", { name: "End session" }).click();
+	await page.getByRole("button", { name: "End Session" }).click();
 	await page.getByLabel("Finished at").fill("11:00");
 	await page.getByRole("button", { name: "Done for the day" }).click();
 
 	// The whole day promotes in one action.
-	await expect(page.getByText("2 sessions ·")).toBeVisible();
+	await expect(promoteStack(page).getByText("2 Sessions ·")).toBeVisible();
 	await page.getByRole("button", { name: "Promote", exact: true }).click();
 	await page.getByRole("button", { name: "Promote day" }).click();
 	await expect(
@@ -108,7 +128,10 @@ test("Captures a day of sessions and promotes it to Activities and a Trip", asyn
 
 	// Promoted Sessions leave the Log...
 	await page.getByRole("dialog").press("Escape");
-	await expect(page.getByText("Nothing captured yet today.")).toBeVisible();
+	await expect(promoteStack(page).getByText("2 Sessions ·")).toBeHidden();
+	await expect(
+		logSection(page, clientA.name).getByText("no Sessions")
+	).toBeVisible();
 	expect(
 		await prisma.workSession.count({ where: { ownerId: logUser.id } })
 	).toBe(0);
@@ -136,6 +159,35 @@ test("Captures a day of sessions and promotes it to Activities and a Trip", asyn
 	expect(Number(trip?.interClientLegs[0].duration)).toBe(20);
 });
 
+test("Every Client keeps a Log section, even with nothing captured", async ({
+	page
+}) => {
+	const captured = await createRandomClient(logUser.id);
+	const untouched = await createRandomClient(logUser.id);
+
+	await page.goto("/dashboard/log");
+	await page.getByRole("button", { name: "Start a Session" }).click();
+	await page.getByRole("checkbox", { name: captured.name }).click();
+	await page.getByLabel("Started at").fill("09:00");
+	await page.getByRole("button", { name: "Start", exact: true }).click();
+	await expect(page.getByText("Session in progress")).toBeVisible();
+
+	// The Log mirrors the notes-app habit: a section per Client, holding that
+	// Client's running list of Sessions.
+	await expect(
+		logSection(page, captured.name).getByText("1 Session")
+	).toBeVisible();
+	await expect(
+		logSection(page, captured.name).getByText("09:00 - open")
+	).toBeVisible();
+
+	// A Client with nothing captured keeps their section as standing
+	// scaffolding rather than disappearing from the Log.
+	await expect(
+		logSection(page, untouched.name).getByText("no Sessions")
+	).toBeVisible();
+});
+
 test("Capture works offline and syncs when signal returns", async ({
 	page,
 	context
@@ -146,7 +198,7 @@ test("Capture works offline and syncs when signal returns", async ({
 
 	// Open the Start flow and wait for the Client list - proof the initial
 	// pull has landed on-device - before dropping the connection.
-	await page.getByRole("button", { name: "Start a session" }).click();
+	await page.getByRole("button", { name: "Start a Session" }).click();
 	await expect(page.getByRole("checkbox", { name: client.name })).toBeVisible();
 	await context.setOffline(true);
 
@@ -186,7 +238,7 @@ test("Open Session banner follows the Provider to other screens", async ({
 	const client = await createRandomClient(logUser.id);
 
 	await page.goto("/dashboard/log");
-	await page.getByRole("button", { name: "Start a session" }).click();
+	await page.getByRole("button", { name: "Start a Session" }).click();
 	await page.getByRole("checkbox", { name: client.name }).click();
 	await page.getByLabel("Started at").fill("09:00");
 	await page.getByRole("button", { name: "Start", exact: true }).click();
@@ -224,9 +276,9 @@ test("A Session left open past its day is ended automatically at 23:59", async (
 	// The console is free for a new day, and yesterday (18:00-23:59, 6h)
 	// joins the promote stack instead of blocking it.
 	await expect(
-		page.getByRole("button", { name: "Start a session" })
+		page.getByRole("button", { name: "Start a Session" })
 	).toBeVisible();
-	await expect(page.getByText("1 session · 6h")).toBeVisible();
+	await expect(promoteStack(page).getByText("1 Session · 6h")).toBeVisible();
 
 	await expect
 		.poll(
@@ -256,7 +308,7 @@ test("Capture flows come up as a drawer on a phone and a dialog on a laptop", as
 	// the bottom edge.
 	await page.setViewportSize({ width: 390, height: 844 });
 	await page.goto("/dashboard/log");
-	await page.getByRole("button", { name: "Start a session" }).click();
+	await page.getByRole("button", { name: "Start a Session" }).click();
 
 	const drawer = page.locator("[data-slot=drawer-popup]");
 	await expect(drawer).toBeVisible();
@@ -271,14 +323,14 @@ test("Capture flows come up as a drawer on a phone and a dialog on a laptop", as
 	await page.getByRole("button", { name: "Start", exact: true }).click();
 	await expect(page.getByText("Session in progress")).toBeVisible();
 
-	await page.getByRole("button", { name: "End session" }).click();
+	await page.getByRole("button", { name: "End Session" }).click();
 	await expect(drawer).toBeVisible();
 	await page.getByRole("dialog").press("Escape");
 	await expect(page.getByRole("dialog")).toHaveCount(0);
 
 	// Laptop: the same flow is a centred dialog, no drawer in the tree.
 	await page.setViewportSize({ width: 1280, height: 900 });
-	await page.getByRole("button", { name: "End session" }).click();
+	await page.getByRole("button", { name: "End Session" }).click();
 	await expect(
 		page.getByRole("heading", { name: "End Session" })
 	).toBeVisible();

--- a/src/components/log/capture-console.tsx
+++ b/src/components/log/capture-console.tsx
@@ -4,6 +4,7 @@
 // a single Start fills the same slot. The prototype's literal warm-paper hex
 // tokens are translated to the theme system here (card/border/primary), so
 // the console follows light and dark mode like the rest of the app.
+import { Button } from "@/components/ui/button";
 import { minutesSince, todayKey } from "@/lib/log/log-time";
 import {
 	costsOf,
@@ -12,10 +13,57 @@ import {
 	tripsOf,
 	type LogSession
 } from "@/lib/log/log-types";
-import { useNowTick } from "@/lib/log/use-log";
-import { TriangleAlert } from "lucide-react";
+import { useNowTick } from "@/hooks/use-log";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
 import { ClientAvatars } from "./client-avatars";
 import type { LogFlows } from "./log-flows";
+import { WarningNote } from "./warning-note";
+
+/**
+ * A two-line capture tile: what it captures on top, what has been captured (or
+ * a hint) underneath. Wider than a Button's own shape - left-aligned, wrapping,
+ * its own height - but built on it so focus, hover, and disabled behave like
+ * every other button in the app.
+ */
+function CaptureTile({
+	tone = "plain",
+	label,
+	hint,
+	onClick
+}: {
+	tone?: "plain" | "primary";
+	label: ReactNode;
+	hint: ReactNode;
+	onClick: () => void;
+}) {
+	const primary = tone === "primary";
+
+	return (
+		<Button
+			variant="outline"
+			className={cn(
+				// justify-start so a tile whose hint wraps to two lines still lines
+				// its label up with the tile beside it.
+				"h-auto flex-col items-start justify-start gap-0.5 px-3 py-2.5 text-left whitespace-normal",
+				primary
+					? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 hover:text-primary"
+					: "bg-card"
+			)}
+			onClick={onClick}
+		>
+			<span className="text-sm font-medium">{label}</span>
+			<span
+				className={cn(
+					"text-xs font-normal",
+					primary ? "text-primary/70" : "text-muted-foreground"
+				)}
+			>
+				{hint}
+			</span>
+		</Button>
+	);
+}
 
 export function CaptureConsole({ flows }: { flows: LogFlows }) {
 	const open = flows.log.openSession;
@@ -25,14 +73,15 @@ export function CaptureConsole({ flows }: { flows: LogFlows }) {
 			<div className="border-primary/40 bg-card overflow-hidden rounded-xl border shadow-sm">
 				<div className="from-primary/10 to-card bg-gradient-to-br p-5 text-center">
 					<div className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
-						No session running
+						No Session running
 					</div>
-					<button
-						className="bg-primary text-primary-foreground hover:bg-primary/90 mt-4 w-full cursor-pointer rounded-lg px-3 py-3 text-sm font-semibold"
+					<Button
+						size="lg"
+						className="mt-4 w-full font-semibold"
 						onClick={() => flows.startSession()}
 					>
-						Start a session
-					</button>
+						Start a Session
+					</Button>
 				</div>
 			</div>
 		);
@@ -88,40 +137,35 @@ function Console({ flows, session }: { flows: LogFlows; session: LogSession }) {
 				    needs the edit sheet, so hand over rather than dead-ending. */}
 				{stale && (
 					<div className="mt-3 flex flex-col items-center gap-2">
-						<p className="flex items-center justify-center gap-2 text-sm text-amber-600 dark:text-amber-500">
-							<TriangleAlert className="size-4 shrink-0" />
+						<WarningNote>
 							Still open from {session.date} - Sessions can&apos;t cross
 							midnight.
-						</p>
-						<button
-							className="border-border bg-card hover:bg-accent cursor-pointer rounded-lg border px-3 py-1.5 text-sm font-medium"
+						</WarningNote>
+						<Button
+							variant="outline"
+							size="sm"
+							className="bg-card"
 							onClick={() => flows.editSession(session)}
 						>
-							Edit session
-						</button>
+							Edit Session
+						</Button>
 					</div>
 				)}
 			</div>
 
 			<div className="border-border grid grid-cols-2 gap-2 border-t p-3">
-				<button
-					className="border-border bg-card hover:bg-accent cursor-pointer rounded-lg border px-3 py-2.5 text-left"
+				<CaptureTile
+					label="+ Trip km"
+					hint={km > 0 ? `${km} km logged` : "driving the client around"}
 					onClick={() => flows.logTrip(session)}
-				>
-					<div className="text-sm font-medium">+ Trip km</div>
-					<div className="text-muted-foreground text-xs">
-						{km > 0 ? `${km} km logged` : "driving the client around"}
-					</div>
-				</button>
-				<button
-					className="border-border bg-card hover:bg-accent cursor-pointer rounded-lg border px-3 py-2.5 text-left"
+				/>
+				<CaptureTile
+					label="+ Travel cost"
+					hint={
+						dollars > 0 ? `$${dollars.toFixed(2)} logged` : "parking, tolls..."
+					}
 					onClick={() => flows.logCost(session)}
-				>
-					<div className="text-sm font-medium">+ Travel cost</div>
-					<div className="text-muted-foreground text-xs">
-						{dollars > 0 ? `$${dollars.toFixed(2)} logged` : "parking, tolls…"}
-					</div>
-				</button>
+				/>
 			</div>
 
 			<div className="border-border space-y-2 border-t p-3">
@@ -130,31 +174,26 @@ function Console({ flows, session }: { flows: LogFlows; session: LogSession }) {
 				    change is the other In-Place shape: a join/leave split of the
 				    running Session. */}
 				<div className="grid grid-cols-2 gap-2">
-					<button
-						className="border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 cursor-pointer rounded-lg border px-3 py-2.5 text-left"
+					<CaptureTile
+						tone="primary"
+						label="⇢ Handover"
+						hint="next Client - add km if you drove"
 						onClick={() => flows.startSession()}
-					>
-						<div className="text-sm font-medium">⇢ Handover</div>
-						<div className="text-primary/70 text-xs">
-							next Client - add km if you drove
-						</div>
-					</button>
-					<button
-						className="border-primary/40 bg-primary/10 text-primary hover:bg-primary/20 cursor-pointer rounded-lg border px-3 py-2.5 text-left"
+					/>
+					<CaptureTile
+						tone="primary"
+						label="⇄ Group change"
+						hint="someone joins or leaves"
 						onClick={() => flows.changeParticipants(session)}
-					>
-						<div className="text-sm font-medium">⇄ Group change</div>
-						<div className="text-primary/70 text-xs">
-							someone joins or leaves
-						</div>
-					</button>
+					/>
 				</div>
-				<button
-					className="bg-primary text-primary-foreground hover:bg-primary/90 w-full cursor-pointer rounded-lg px-3 py-3 text-sm font-semibold"
+				<Button
+					size="lg"
+					className="w-full font-semibold"
 					onClick={() => flows.endSession(session)}
 				>
-					End session
-				</button>
+					End Session
+				</Button>
 			</div>
 		</div>
 	);

--- a/src/components/log/log-flows.tsx
+++ b/src/components/log/log-flows.tsx
@@ -28,16 +28,18 @@ import {
 	deleteSession,
 	editSession,
 	endSession,
+	getLogState,
 	recordCost,
 	recordTrip,
 	startSession
 } from "@/lib/log/log-store";
 import { minutesBetween, nowHHmm, todayKey } from "@/lib/log/log-time";
 import type { LogSession, LogTransportItem } from "@/lib/log/log-types";
-import type { Log } from "@/lib/log/use-log";
-import { Car, CircleDollarSign, TriangleAlert, X } from "lucide-react";
+import type { Log } from "@/hooks/use-log";
+import { Car, CircleDollarSign, X } from "lucide-react";
 import { useState } from "react";
 import { PromoteDialog } from "./promote-dialog";
+import { WarningNote } from "./warning-note";
 
 const errorMessage = (error: unknown) =>
 	error instanceof Error ? error.message : "Something went wrong";
@@ -84,7 +86,11 @@ export function useLogFlows(log: Log) {
 					/>
 				)}
 				{endState && (
-					<EndDialog session={endState} onClose={() => setEndState(null)} />
+					<EndDialog
+						session={endState}
+						onClose={() => setEndState(null)}
+						onMoreToCome={() => setStartState(true)}
+					/>
 				)}
 				{handoverState && (
 					<HandoverDialog
@@ -254,18 +260,23 @@ function StartDialog({
 
 function EndDialog({
 	session,
-	onClose
+	onClose,
+	onMoreToCome
 }: {
 	session: LogSession;
 	onClose: () => void;
+	onMoreToCome: () => void;
 }) {
 	const [time, setTime] = useState(nowHHmm());
 	const [error, setError] = useState<string | null>(null);
 
-	const submit = () => {
+	const submit = (moreToCome: boolean) => {
 		try {
 			endSession(session.id, time);
 			onClose();
+			// "More to come" chains straight into starting the next Client, whose
+			// Start captures the handover drive - no extra navigation (story 8).
+			if (moreToCome) onMoreToCome();
 		} catch (submitError) {
 			setError(errorMessage(submitError));
 		}
@@ -294,13 +305,14 @@ function EndDialog({
 				</div>
 				<ErrorNote message={error} />
 				<div className="flex flex-col gap-2">
-					<Button onClick={submit}>More clients to come</Button>
-					<Button variant="secondary" onClick={submit}>
+					<Button onClick={() => submit(true)}>More clients to come</Button>
+					<Button variant="secondary" onClick={() => submit(false)}>
 						Done for the day
 					</Button>
 				</div>
 				<p className="text-muted-foreground text-xs">
-					More to come? Starting the next Client will ask how far you drove.
+					More to come? You&apos;ll pick the next Client straight away, and
+					starting them asks how far you drove.
 				</p>
 			</ResponsiveDialogContent>
 		</ResponsiveDialog>
@@ -336,12 +348,26 @@ function HandoverDialog({
 			});
 			onClose();
 		} catch (submitError) {
+			// The dialog can't be dismissed, so the one unanswerable failure -
+			// the Session vanished mid-prompt (a concurrent delete syncing in) -
+			// must let go rather than trap the Provider behind a dead error.
+			if (
+				!getLogState().sessions.some(
+					(session) => session.id === state.sessionId
+				)
+			) {
+				onClose();
+				return;
+			}
 			setError(errorMessage(submitError));
 		}
 	};
 
 	return (
-		<ResponsiveDialog open onOpenChange={(open) => !open && onClose()}>
+		// Not dismissible: whether you drove is exactly what Promotion bills, so
+		// the question can't be swiped away - it never comes back (the prompt
+		// only fires at next-Start) and a silent gap would just underbill.
+		<ResponsiveDialog open dismissible={false}>
 			<ResponsiveDialogContent>
 				<ResponsiveDialogHeader>
 					<ResponsiveDialogTitle>How did you get here?</ResponsiveDialogTitle>
@@ -377,11 +403,10 @@ function HandoverDialog({
 					/>
 				</div>
 				{exceedsGap && (
-					<p className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-500">
-						<TriangleAlert className="size-4 shrink-0" />
+					<WarningNote>
 						Longer than the {state.gapMinutes} min gap - only what fits will
 						bill.
-					</p>
+					</WarningNote>
 				)}
 				<ErrorNote message={error} />
 				<div className="flex flex-col gap-2">
@@ -390,9 +415,6 @@ function HandoverDialog({
 					</Button>
 					<Button variant="secondary" onClick={() => submit("IN_PLACE")}>
 						We stayed in place
-					</Button>
-					<Button variant="ghost" onClick={onClose}>
-						Skip
 					</Button>
 				</div>
 			</ResponsiveDialogContent>
@@ -597,7 +619,7 @@ function ParticipantDialog({
 							className="flex items-center justify-between gap-2 rounded-md px-2 py-1"
 						>
 							<span className="min-w-0 break-words">
-								{log.participantNames({ ...session, clientIds: [clientId] })}
+								{log.clientName(clientId)}
 							</span>
 							<Button
 								className="shrink-0"

--- a/src/components/log/open-session-banner.tsx
+++ b/src/components/log/open-session-banner.tsx
@@ -3,8 +3,9 @@
 // lets the Provider log a trip, log a travel cost, or end it without
 // hunting for the Log tab. Hidden on the Log tab itself, where the capture
 // console is the banner.
+import { Button } from "@/components/ui/button";
 import { formatMinutes, minutesSince, todayKey } from "@/lib/log/log-time";
-import { useLog, useNowTick } from "@/lib/log/use-log";
+import { useLog, useNowTick } from "@/hooks/use-log";
 import { Car, CircleDollarSign } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -40,28 +41,30 @@ export function OpenSessionBanner() {
 					</Link>
 					{/* Icon-only on phones so the Client and elapsed time stay
 					    readable; the dialogs they open are fully labelled. */}
-					<button
+					<Button
+						variant="ghost"
 						aria-label="Log trip km"
-						className="text-primary hover:bg-primary/20 flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium"
+						className="text-primary hover:bg-primary/20 hover:text-primary h-7 shrink-0 gap-1 px-2 text-xs"
 						onClick={() => flows.logTrip(session)}
 					>
-						<Car className="size-4" />
+						<Car />
 						<span className="hidden sm:inline">+ Trip km</span>
-					</button>
-					<button
+					</Button>
+					<Button
+						variant="ghost"
 						aria-label="Log travel cost"
-						className="text-primary hover:bg-primary/20 flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium"
+						className="text-primary hover:bg-primary/20 hover:text-primary h-7 shrink-0 gap-1 px-2 text-xs"
 						onClick={() => flows.logCost(session)}
 					>
-						<CircleDollarSign className="size-4" />
+						<CircleDollarSign />
 						<span className="hidden sm:inline">+ Travel cost</span>
-					</button>
-					<button
-						className="bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer rounded-md px-2.5 py-1 text-xs font-semibold"
+					</Button>
+					<Button
+						className="h-7 shrink-0 px-2.5 text-xs font-semibold"
 						onClick={() => flows.endSession(session)}
 					>
 						End
-					</button>
+					</Button>
 				</div>
 			</div>
 			{flows.dialogs}

--- a/src/components/log/promote-dialog.tsx
+++ b/src/components/log/promote-dialog.tsx
@@ -22,12 +22,12 @@ import {
 import { dropDay } from "@/lib/log/log-store";
 import { formatDayKey } from "@/lib/log/log-time";
 import { isGroupSession, type LogSession } from "@/lib/log/log-types";
-import type { Log } from "@/lib/log/use-log";
+import type { Log } from "@/hooks/use-log";
 import { trpc } from "@/lib/trpc";
-import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { SessionMeta } from "./session-meta";
+import { WarningNote } from "./warning-note";
 
 export function PromoteDialog({
 	log,
@@ -132,7 +132,7 @@ export function PromoteDialog({
 												{log.participantNames(session)}
 											</span>
 											<span className="text-muted-foreground shrink-0 font-mono text-xs">
-												{session.startTime}–
+												{session.startTime} -{" "}
 												{session.endTime ?? (
 													<Badge variant="destructive">open</Badge>
 												)}
@@ -168,12 +168,7 @@ export function PromoteDialog({
 								);
 							})}
 						</div>
-						{blocker && (
-							<p className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-500">
-								<TriangleAlert className="size-4 shrink-0" />
-								{blocker}
-							</p>
-						)}
+						{blocker && <WarningNote>{blocker}</WarningNote>}
 						{promote.error && (
 							<p className="text-destructive text-sm">
 								{promote.error.message}

--- a/src/components/log/warning-note.tsx
+++ b/src/components/log/warning-note.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+import { TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * The Log's one warning voice. Every capture surface warns rather than blocks -
+ * a mistyped travel time, a Session left open past its day, a day that can't
+ * promote yet - so they all read the same way.
+ */
+export function WarningNote({
+	className,
+	children
+}: {
+	className?: string;
+	children: ReactNode;
+}) {
+	return (
+		<p
+			className={cn(
+				"flex items-start gap-2 text-sm text-amber-600 dark:text-amber-500",
+				className
+			)}
+		>
+			<TriangleAlert className="mt-0.5 size-4 shrink-0" />
+			<span>{children}</span>
+		</p>
+	);
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,8 +29,11 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
 	React.ElementRef<typeof DialogPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+		/** Hide the corner X for dialogs that must be answered, not dismissed. */
+		showCloseButton?: boolean;
+	}
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
 	<DialogPortal>
 		<DialogOverlay />
 		<DialogPrimitive.Content
@@ -42,10 +45,12 @@ const DialogContent = React.forwardRef<
 			{...props}
 		>
 			{children}
-			<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-				<X className="h-4 w-4" />
-				<span className="sr-only">Close</span>
-			</DialogPrimitive.Close>
+			{showCloseButton && (
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+					<X className="h-4 w-4" />
+					<span className="sr-only">Close</span>
+				</DialogPrimitive.Close>
+			)}
 		</DialogPrimitive.Content>
 	</DialogPortal>
 ));

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -57,8 +57,12 @@ const DrawerSwipeHandle = ({
 const DrawerContent = ({
 	className,
 	children,
+	showHandle = true,
 	...props
-}: DrawerPrimitive.Popup.Props) => (
+}: DrawerPrimitive.Popup.Props & {
+	/** Hide the grab handle for drawers that must be answered, not swiped away. */
+	showHandle?: boolean;
+}) => (
 	<DrawerPrimitive.Portal data-slot="drawer-portal">
 		<DrawerOverlay />
 		<DrawerPrimitive.Viewport
@@ -80,7 +84,7 @@ const DrawerContent = ({
 				)}
 				{...props}
 			>
-				<DrawerSwipeHandle />
+				{showHandle ? <DrawerSwipeHandle /> : <div className="pt-2" />}
 				<DrawerPrimitive.Content
 					data-slot="drawer-content"
 					className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain px-6 pt-2 pb-[max(1.5rem,env(safe-area-inset-bottom))] select-text"

--- a/src/components/ui/responsive-dialog.tsx
+++ b/src/components/ui/responsive-dialog.tsx
@@ -23,35 +23,74 @@ import {
 } from "@/components/ui/drawer";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { cn } from "@/lib/utils";
-import { createContext, useContext, type ReactNode } from "react";
+import {
+	createContext,
+	useContext,
+	type ComponentType,
+	type ReactNode
+} from "react";
 
-// Which primitive the surrounding root chose. The parts read it rather than
-// calling useIsMobile again so a resize mid-flow can never split a single
-// modal across both primitives.
-const DrawerVariant = createContext(false);
-
-const useDrawerVariant = () => useContext(DrawerVariant);
+// Which primitive the surrounding root chose, and whether the modal can be
+// light-dismissed. The parts read it rather than calling useIsMobile again so
+// a resize mid-flow can never split a single modal across both primitives.
+const Variant = createContext({ drawer: false, dismissible: true });
 
 type Part = { className?: string; children?: ReactNode };
+
+/**
+ * One part of the modal, in both flavours. `dialogClassName` carries whatever
+ * the desktop primitive needs on top of its own defaults; the caller's own
+ * className always lands last.
+ */
+function responsivePart(
+	DrawerPart: ComponentType<Part>,
+	DialogPart: ComponentType<Part>,
+	dialogClassName?: string
+) {
+	const ResponsivePart = ({ className, children }: Part) =>
+		useContext(Variant).drawer ? (
+			<DrawerPart className={className}>{children}</DrawerPart>
+		) : (
+			<DialogPart className={cn(dialogClassName, className)}>
+				{children}
+			</DialogPart>
+		);
+	ResponsivePart.displayName = `Responsive${DialogPart.displayName ?? DialogPart.name}`;
+	return ResponsivePart;
+}
 
 function ResponsiveDialog({
 	open,
 	onOpenChange,
+	dismissible = true,
 	children
 }: {
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
+	/**
+	 * `false` removes every light-dismiss route - Escape, outside press, the
+	 * dialog's corner X, the drawer's swipe - so the modal only closes through
+	 * one of its own actions. For questions that must be answered.
+	 */
+	dismissible?: boolean;
 	children?: ReactNode;
 }) {
 	const isMobile = useIsMobile();
 	// Radix hands the callback one argument, Base UI two - normalise to the
-	// boolean both agree on.
-	const change = (next: boolean) => onOpenChange?.(next);
+	// boolean both agree on. Both primitives are controlled by `open`, so a
+	// non-dismissible modal simply never forwards their close requests.
+	const change = dismissible
+		? (next: boolean) => onOpenChange?.(next)
+		: undefined;
 
 	return (
-		<DrawerVariant.Provider value={isMobile}>
+		<Variant.Provider value={{ drawer: isMobile, dismissible }}>
 			{isMobile ? (
-				<Drawer open={open} onOpenChange={change}>
+				<Drawer
+					open={open}
+					onOpenChange={change}
+					disablePointerDismissal={!dismissible}
+				>
 					{children}
 				</Drawer>
 			) : (
@@ -59,69 +98,36 @@ function ResponsiveDialog({
 					{children}
 				</Dialog>
 			)}
-		</DrawerVariant.Provider>
+		</Variant.Provider>
 	);
 }
 
-function ResponsiveDialogContent({ className, children }: Part) {
-	const isDrawer = useDrawerVariant();
-
-	if (isDrawer) {
-		return <DrawerContent className={className}>{children}</DrawerContent>;
-	}
-
-	// Capture flows are a phone-shaped column of one or two fields; the desktop
-	// dialog holds that width instead of stretching to Dialog's default.
-	return (
-		<DialogContent className={cn("max-w-sm", className)}>
+// Capture flows are a phone-shaped column of one or two fields; the desktop
+// dialog holds that width instead of stretching to Dialog's default. Content
+// is hand-rolled rather than a responsivePart because it also hides the
+// close affordances (corner X, swipe handle) when the root is non-dismissible.
+const ResponsiveDialogContent = ({ className, children }: Part) => {
+	const { drawer, dismissible } = useContext(Variant);
+	return drawer ? (
+		<DrawerContent className={className} showHandle={dismissible}>
+			{children}
+		</DrawerContent>
+	) : (
+		<DialogContent
+			className={cn("max-w-sm", className)}
+			showCloseButton={dismissible}
+		>
 			{children}
 		</DialogContent>
 	);
-}
-
-function ResponsiveDialogHeader({ className, children }: Part) {
-	const isDrawer = useDrawerVariant();
-
-	if (isDrawer) {
-		return <DrawerHeader className={className}>{children}</DrawerHeader>;
-	}
-
-	return <DialogHeader className={className}>{children}</DialogHeader>;
-}
-
-function ResponsiveDialogFooter({ className, children }: Part) {
-	const isDrawer = useDrawerVariant();
-
-	if (isDrawer) {
-		return <DrawerFooter className={className}>{children}</DrawerFooter>;
-	}
-
-	return <DialogFooter className={className}>{children}</DialogFooter>;
-}
-
-function ResponsiveDialogTitle({ className, children }: Part) {
-	const isDrawer = useDrawerVariant();
-
-	if (isDrawer) {
-		return <DrawerTitle className={className}>{children}</DrawerTitle>;
-	}
-
-	return <DialogTitle className={className}>{children}</DialogTitle>;
-}
-
-function ResponsiveDialogDescription({ className, children }: Part) {
-	const isDrawer = useDrawerVariant();
-
-	if (isDrawer) {
-		return (
-			<DrawerDescription className={className}>{children}</DrawerDescription>
-		);
-	}
-
-	return (
-		<DialogDescription className={className}>{children}</DialogDescription>
-	);
-}
+};
+const ResponsiveDialogHeader = responsivePart(DrawerHeader, DialogHeader);
+const ResponsiveDialogFooter = responsivePart(DrawerFooter, DialogFooter);
+const ResponsiveDialogTitle = responsivePart(DrawerTitle, DialogTitle);
+const ResponsiveDialogDescription = responsivePart(
+	DrawerDescription,
+	DialogDescription
+);
 
 export {
 	ResponsiveDialog,

--- a/src/hooks/use-log.ts
+++ b/src/hooks/use-log.ts
@@ -1,8 +1,19 @@
 // React view over the Log store: subscribe + the derived shapes every Log
-// surface needs (the Open Session, sessions grouped by day, client names).
+// surface needs (the Open Session, sessions grouped by day and by Client,
+// client names).
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import { getLogState, subscribeLog } from "./log-store";
-import { EMPTY_LOG_STATE, type LogSession } from "./log-types";
+import { getLogState, subscribeLog } from "@/lib/log/log-store";
+import {
+	EMPTY_LOG_STATE,
+	type LogClient,
+	type LogSession
+} from "@/lib/log/log-types";
+
+/** A Client's section of the Log - kept even when it holds no Sessions. */
+export interface ClientSection {
+	client: LogClient;
+	sessions: LogSession[];
+}
 
 export function useLog() {
 	const state = useSyncExternalStore(
@@ -15,6 +26,9 @@ export function useLog() {
 		const clientNameById = new Map(
 			state.clients.map((client) => [client.id, client.name])
 		);
+		const clientName = (clientId: string) =>
+			clientNameById.get(clientId) ?? "A Client";
+
 		const sessionsByDay = new Map<string, LogSession[]>();
 		for (const session of state.sessions) {
 			sessionsByDay.set(session.date, [
@@ -23,14 +37,28 @@ export function useLog() {
 			]);
 		}
 
+		// The per-Client sections of the Log, mirroring the server's listByClient
+		// shape: every Client keeps a section as standing scaffolding, and a group
+		// Session appears under each of its participants.
+		const sessionsByClient: ClientSection[] = state.clients.map((client) => ({
+			client,
+			sessions: state.sessions.filter((session) =>
+				session.clientIds.includes(client.id)
+			)
+		}));
+
+		// Participants are stored in id order so both sides agree on which one is
+		// primary; names read alphabetically instead.
 		const participantNameList = (session: LogSession) =>
-			session.clientIds.map((id) => clientNameById.get(id) ?? "A Client");
+			session.clientIds.map(clientName).sort((a, b) => a.localeCompare(b));
 
 		return {
 			...state,
 			openSession:
 				state.sessions.find((session) => session.endTime === null) ?? null,
 			sessionsByDay,
+			sessionsByClient,
+			clientName,
 			participantNameList,
 			participantNames: (session: LogSession) =>
 				participantNameList(session).join(" + ")

--- a/src/lib/log/log-store.test.ts
+++ b/src/lib/log/log-store.test.ts
@@ -1,0 +1,368 @@
+// The offline half of the Log, tested with no signal at all: every capture
+// has to land in local state and queue its replay, and the guards that mirror
+// the router have to reject at tap time rather than at sync time. The store
+// keeps module-level state, so each test imports a fresh copy.
+import type { PersistedLog } from "@/lib/log/log-db";
+import type { LogOp, LogSession } from "@/lib/log/log-types";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { persisted } = vi.hoisted(() => ({
+	persisted: { current: null as PersistedLog | null }
+}));
+
+vi.mock("@/lib/log/log-db", () => ({
+	loadPersistedLog: async () => persisted.current,
+	savePersistedLog: async (state: PersistedLog) => {
+		persisted.current = state;
+	}
+}));
+
+type Store = typeof import("@/lib/log/log-store");
+
+const ALICE = "client-aaa";
+const BOB = "client-zzz";
+
+async function freshStore(seed?: PersistedLog): Promise<Store> {
+	persisted.current = seed ?? null;
+	vi.resetModules();
+	return import("@/lib/log/log-store");
+}
+
+/** A store that has hydrated from `seed`, the way a returning tab does. */
+async function hydratedStore(seed: PersistedLog): Promise<Store> {
+	const store = await freshStore(seed);
+	store.subscribeLog(() => {});
+	await vi.waitFor(() => expect(store.getLogState().hydrated).toBe(true));
+	return store;
+}
+
+const session = (overrides: Partial<LogSession> = {}): LogSession => ({
+	id: "session-1",
+	date: "2020-01-01",
+	startTime: "09:00",
+	endTime: null,
+	clientIds: [ALICE],
+	precededById: null,
+	handoverType: null,
+	interClientDistance: null,
+	interClientDuration: null,
+	transportItems: [],
+	updatedAt: "2020-01-01T09:00:00.000Z",
+	...overrides
+});
+
+const seedOf = (sessions: LogSession[]): PersistedLog => ({
+	sessions,
+	clients: [
+		{ id: ALICE, name: "Zoe" },
+		{ id: BOB, name: "Adam" }
+	],
+	queue: [],
+	autoEnded: []
+});
+
+const queuedKinds = (store: Store) =>
+	store.getLogState().queue.map((op: LogOp) => op.kind);
+
+beforeEach(() => {
+	// Every test runs with no signal: captures stay on-device and the queue
+	// never drains, which is exactly the state the field cares about.
+	vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+});
+
+describe("capture", () => {
+	test("a Start opens a Session locally and queues its replay", async () => {
+		const store = await freshStore();
+
+		const { session: started, previous } = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		});
+
+		expect(previous).toBeNull();
+		expect(store.getLogState().sessions).toEqual([started]);
+		expect(started.endTime).toBeNull();
+		expect(queuedKinds(store)).toEqual(["start"]);
+		// The tap is stamped with the moment it happened, not the moment it syncs.
+		expect(Date.parse(started.updatedAt)).toBeLessThanOrEqual(Date.now());
+	});
+
+	test("participants are stored in id order however they were tapped", async () => {
+		const store = await freshStore();
+
+		const { session: started } = store.startSession({
+			clientIds: [BOB, ALICE, BOB],
+			startTime: "09:00"
+		});
+
+		// Promotion bills a group Session's transport on the first participant,
+		// so local order has to match the order the server reads them back in.
+		expect(started.clientIds).toEqual([ALICE, BOB]);
+	});
+
+	test("starting the next Client closes the open Session and offers the handover", async () => {
+		const store = await freshStore();
+		const first = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		}).session;
+
+		const { previous } = store.startSession({
+			clientIds: [BOB],
+			startTime: "10:20"
+		});
+
+		expect(previous?.id).toBe(first.id);
+		const closed = store
+			.getLogState()
+			.sessions.find((s) => s.id === first.id) as LogSession;
+		expect(closed.endTime).toBe("10:20");
+		expect(store.getLogState().sessions.filter((s) => !s.endTime)).toHaveLength(
+			1
+		);
+	});
+
+	test("a Start before the open Session began is refused at tap time", async () => {
+		const store = await freshStore();
+		store.startSession({ clientIds: [ALICE], startTime: "10:00" });
+
+		expect(() =>
+			store.startSession({ clientIds: [BOB], startTime: "09:00" })
+		).toThrow(/right time first/);
+		expect(queuedKinds(store)).toEqual(["start"]);
+	});
+
+	test("an End at or before the Start is refused", async () => {
+		const store = await freshStore();
+		const started = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		}).session;
+
+		expect(() => store.endSession(started.id, "09:00")).toThrow();
+		expect(store.getLogState().sessions[0].endTime).toBeNull();
+	});
+
+	test("a trip and a cost attach to the Session and queue separately", async () => {
+		const store = await freshStore();
+		const started = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		}).session;
+
+		store.recordTrip({ workSessionId: started.id, distance: 8 });
+		store.recordCost({
+			workSessionId: started.id,
+			type: "PARKING",
+			amount: 4.5
+		});
+		expect(() =>
+			store.recordTrip({ workSessionId: started.id, distance: 0 })
+		).toThrow(/positive/);
+
+		expect(store.getLogState().sessions[0].transportItems).toMatchObject([
+			{ type: "DISTANCE", amount: 8 },
+			{ type: "PARKING", amount: 4.5 }
+		]);
+		expect(queuedKinds(store)).toEqual(["start", "recordTrip", "recordCost"]);
+	});
+
+	test("a composition change splits the Session at the pivot with no driving", async () => {
+		const store = await freshStore();
+		const solo = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		}).session;
+
+		const group = store.changeParticipants({
+			workSessionId: solo.id,
+			clientId: BOB,
+			at: "10:00",
+			change: "add"
+		});
+
+		const sessions = store.getLogState().sessions;
+		expect(sessions.find((s) => s.id === solo.id)?.endTime).toBe("10:00");
+		expect(group).toMatchObject({
+			startTime: "10:00",
+			endTime: null,
+			precededById: solo.id,
+			handoverType: "IN_PLACE",
+			interClientDistance: null,
+			clientIds: [ALICE, BOB]
+		});
+		expect(queuedKinds(store)).toEqual(["start", "addParticipant"]);
+	});
+
+	test("a Session can't be left with no Clients", async () => {
+		const store = await freshStore();
+		const solo = store.startSession({
+			clientIds: [ALICE],
+			startTime: "09:00"
+		}).session;
+
+		expect(() =>
+			store.changeParticipants({
+				workSessionId: solo.id,
+				clientId: ALICE,
+				at: "10:00",
+				change: "remove"
+			})
+		).toThrow(/at least one Client/);
+	});
+
+	test("a travel Handover needs a distance", async () => {
+		const store = await hydratedStore(seedOf([session({ endTime: "10:00" })]));
+		const next = store.startSession({
+			clientIds: [BOB],
+			startTime: "10:20"
+		}).session;
+
+		expect(() =>
+			store.captureHandover({
+				workSessionId: next.id,
+				precededByWorkSessionId: "session-1",
+				handoverType: "TRAVEL"
+			})
+		).toThrow(/Distance is required/);
+
+		store.captureHandover({
+			workSessionId: next.id,
+			precededByWorkSessionId: "session-1",
+			handoverType: "TRAVEL",
+			interClientDistance: 12,
+			interClientDuration: 20
+		});
+		expect(
+			store.getLogState().sessions.find((s) => s.id === next.id)
+		).toMatchObject({
+			precededById: "session-1",
+			handoverType: "TRAVEL",
+			interClientDistance: 12,
+			interClientDuration: 20
+		});
+	});
+});
+
+describe("editing a capture", () => {
+	test("a backfilled Session that stays Open is refused while one is already Open", async () => {
+		const store = await freshStore();
+		store.startSession({ clientIds: [ALICE], startTime: "09:00" });
+
+		expect(() =>
+			store.editSession({
+				id: null,
+				date: "2020-01-01",
+				startTime: "09:00",
+				endTime: null,
+				clientIds: [BOB]
+			})
+		).toThrow(/open/i);
+	});
+
+	test("a backfilled past Session lands closed and queues an edit", async () => {
+		const store = await freshStore();
+
+		store.editSession({
+			id: null,
+			date: "2020-01-01",
+			startTime: "09:00",
+			endTime: "11:00",
+			clientIds: [BOB, ALICE]
+		});
+
+		expect(store.getLogState().sessions).toMatchObject([
+			{ date: "2020-01-01", endTime: "11:00", clientIds: [ALICE, BOB] }
+		]);
+		expect(queuedKinds(store)).toEqual(["edit"]);
+	});
+
+	test("deleting a Session also drops the handover that pointed at it", async () => {
+		const store = await hydratedStore(
+			seedOf([
+				session({ id: "first", endTime: "10:00" }),
+				session({
+					id: "second",
+					startTime: "10:20",
+					endTime: "11:00",
+					precededById: "first",
+					handoverType: "TRAVEL",
+					interClientDistance: 12
+				})
+			])
+		);
+
+		store.deleteSession("first");
+
+		expect(store.getLogState().sessions).toMatchObject([
+			{ id: "second", precededById: null, handoverType: null }
+		]);
+		expect(queuedKinds(store)).toEqual(["delete"]);
+	});
+});
+
+describe("a Session left open past its day", () => {
+	test("ends at 23:59 on hydration and nudges for review", async () => {
+		const store = await hydratedStore(seedOf([session()]));
+
+		const state = store.getLogState();
+		expect(state.sessions[0].endTime).toBe("23:59");
+		expect(state.autoEnded).toEqual(["session-1"]);
+		expect(queuedKinds(store)).toEqual(["end"]);
+
+		store.dismissAutoEnded("session-1");
+		expect(store.getLogState().autoEnded).toEqual([]);
+	});
+
+	test("is left alone when it started in the day's final minute", async () => {
+		const store = await hydratedStore(
+			seedOf([session({ startTime: "23:59" })])
+		);
+
+		// No end after 23:59 exists, so the console hands the Provider an edit
+		// rather than inventing an impossible one.
+		expect(store.getLogState().sessions[0].endTime).toBeNull();
+		expect(store.getLogState().autoEnded).toEqual([]);
+	});
+
+	test("saving an edit answers the nudge", async () => {
+		const store = await hydratedStore(seedOf([session()]));
+		expect(store.getLogState().autoEnded).toEqual(["session-1"]);
+
+		store.editSession({
+			id: "session-1",
+			date: "2020-01-01",
+			startTime: "09:00",
+			endTime: "17:30",
+			clientIds: [ALICE]
+		});
+
+		expect(store.getLogState().autoEnded).toEqual([]);
+		expect(store.getLogState().sessions[0].endTime).toBe("17:30");
+	});
+});
+
+describe("persistence", () => {
+	test("captures survive the tab closing", async () => {
+		const store = await freshStore();
+		store.startSession({ clientIds: [ALICE], startTime: "09:00" });
+
+		await vi.waitFor(() => expect(persisted.current).not.toBeNull());
+		expect(persisted.current?.sessions).toHaveLength(1);
+		expect(persisted.current?.queue.map((op) => op.kind)).toEqual(["start"]);
+	});
+
+	test("a promoted day is dropped locally without queueing anything", async () => {
+		const store = await hydratedStore(
+			seedOf([
+				session({ endTime: "10:00" }),
+				session({ id: "other", date: "2020-01-02", endTime: "10:00" })
+			])
+		);
+
+		store.dropDay("2020-01-01");
+
+		expect(store.getLogState().sessions.map((s) => s.id)).toEqual(["other"]);
+		expect(queuedKinds(store)).toEqual([]);
+	});
+});

--- a/src/lib/log/log-store.ts
+++ b/src/lib/log/log-store.ts
@@ -71,7 +71,19 @@ function commit(patch: Partial<LogState>) {
 	});
 }
 
+// A client-generated id so an offline create has stable identity and its
+// replay is an idempotent upsert. The column is a plain string, so this is a
+// UUID rather than the cuid Prisma mints server-side - same guarantee, no
+// extra dependency to generate one on-device.
 const newId = () => crypto.randomUUID();
+
+/**
+ * Participants are deduped and ordered by id, the same order the server reads
+ * them back in. Promotion treats the first as the Session's primary
+ * participant, so both sides have to agree on who that is.
+ */
+const participantIds = (clientIds: string[]) =>
+	[...new Set(clientIds)].sort((a, b) => a.localeCompare(b));
 
 const sortSessions = (sessions: LogSession[]) =>
 	[...sessions].sort(
@@ -110,7 +122,7 @@ export function startSession(input: {
 	startTime: string;
 }): StartResult {
 	const date = todayKey();
-	const clientIds = [...new Set(input.clientIds)];
+	const clientIds = participantIds(input.clientIds);
 	if (clientIds.length === 0) throw new Error("Pick at least one Client");
 
 	const open = openSessionOf(state.sessions);
@@ -228,7 +240,7 @@ export function editSession(input: {
 	clientIds: string[];
 	transportItems?: LogSession["transportItems"];
 }) {
-	const clientIds = [...new Set(input.clientIds)];
+	const clientIds = participantIds(input.clientIds);
 	if (clientIds.length === 0) throw new Error("Pick at least one Client");
 	if (
 		input.endTime !== null &&
@@ -370,7 +382,7 @@ export function changeParticipants(input: {
 		if (session.clientIds.includes(input.clientId)) {
 			throw new Error("That Client is already in this Session");
 		}
-		clientIds = [...session.clientIds, input.clientId];
+		clientIds = participantIds([...session.clientIds, input.clientId]);
 	} else {
 		clientIds = session.clientIds.filter((id) => id !== input.clientId);
 		if (clientIds.length === session.clientIds.length) {

--- a/src/pages/dashboard/log.tsx
+++ b/src/pages/dashboard/log.tsx
@@ -1,18 +1,20 @@
-// The Log tab: the field-capture console on top, today's captured Sessions
-// below it, and the stack of days waiting to promote - the phone-first
-// mirror of the notes-app habit (issue #464 stage 3, shaped by the stage-2
-// prototype verdict). Everything renders from the on-device store, so this
-// page works identically with and without signal.
+// The Log tab: the field-capture console on top, the per-Client sections that
+// mirror the notes-app habit below it, and the stack of days waiting to
+// promote - the phone-first shape of issue #464 stage 3, shaped by the stage-2
+// prototype verdict. Everything renders from the on-device store, so this page
+// works identically with and without signal.
 import { CaptureConsole } from "@/components/log/capture-console";
 import { ClientAvatars } from "@/components/log/client-avatars";
 import { useLogFlows, type LogFlows } from "@/components/log/log-flows";
 import { SessionMeta } from "@/components/log/session-meta";
+import { WarningNote } from "@/components/log/warning-note";
 import Layout from "@/components/shared/layout";
+import { Button } from "@/components/ui/button";
 import { clearSyncError, dismissAutoEnded } from "@/lib/log/log-store";
 import { formatDayKey, minutesBetween, todayKey } from "@/lib/log/log-time";
 import type { LogSession } from "@/lib/log/log-types";
-import { useLog } from "@/lib/log/use-log";
-import { CloudOff, RefreshCw, TriangleAlert } from "lucide-react";
+import { useLog, type ClientSection } from "@/hooks/use-log";
+import { CloudOff, RefreshCw } from "lucide-react";
 import Head from "next/head";
 import { useEffect } from "react";
 import { toast } from "react-toastify";
@@ -28,6 +30,9 @@ const dayHours = (sessions: LogSession[]) =>
 		sessions.reduce((sum, session) => sum + sessionMinutes(session), 0)
 	);
 
+const plural = (count: number, word: string) =>
+	`${count} ${word}${count === 1 ? "" : "s"}`;
+
 function SyncStatus({ online, pending }: { online: boolean; pending: number }) {
 	if (online && pending === 0) return null;
 
@@ -39,7 +44,7 @@ function SyncStatus({ online, pending }: { online: boolean; pending: number }) {
 				<CloudOff className="size-3.5 shrink-0" />
 			)}
 			{online
-				? `Syncing ${pending} capture${pending === 1 ? "" : "s"}...`
+				? `Syncing ${plural(pending, "capture")}...`
 				: `Offline - captures are saved on this device${
 						pending > 0 ? ` (${pending} waiting to sync)` : ""
 					} and sync when you're back in signal.`}
@@ -64,29 +69,28 @@ function AutoEndNudge({ flows }: { flows: LogFlows }) {
 					key={session.id}
 					className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4"
 				>
-					<p className="flex items-start gap-2 text-sm">
-						<TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
-						<span>
-							<span className="font-medium">
-								{log.participantNames(session)}
-							</span>{" "}
-							was left open on {formatDayKey(session.date)} and ended for you at
-							23:59 - is that when you finished?
-						</span>
-					</p>
+					<WarningNote>
+						<span className="font-medium">{log.participantNames(session)}</span>{" "}
+						was left open on {formatDayKey(session.date)} and ended for you at
+						23:59 - is that when you finished?
+					</WarningNote>
 					<div className="mt-3 flex gap-2">
-						<button
-							className="border-border bg-card hover:bg-accent flex-1 cursor-pointer rounded-lg border px-3 py-1.5 text-sm font-medium"
+						<Button
+							variant="outline"
+							size="sm"
+							className="bg-card flex-1"
 							onClick={() => flows.editSession(session)}
 						>
 							Fix end time
-						</button>
-						<button
-							className="text-muted-foreground hover:bg-accent flex-1 cursor-pointer rounded-lg px-3 py-1.5 text-sm"
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground flex-1"
 							onClick={() => dismissAutoEnded(session.id)}
 						>
 							23:59 is right
-						</button>
+						</Button>
 					</div>
 				</div>
 			))}
@@ -94,54 +98,98 @@ function AutoEndNudge({ flows }: { flows: LogFlows }) {
 	);
 }
 
-function EarlierToday({ flows }: { flows: LogFlows }) {
-	const { log } = flows;
-	const earlier = (log.sessionsByDay.get(todayKey()) ?? []).filter(
-		(session) => session.endTime !== null
-	);
+/**
+ * The Log's per-Client sections: one for every Client, holding that Client's
+ * Sessions not yet turned into Activities. A section stays even when it is
+ * empty - standing scaffolding for the Clients a Provider works with
+ * regularly - and a group Session appears under each of its participants.
+ */
+function ClientSections({ flows }: { flows: LogFlows }) {
+	const sections = flows.log.sessionsByClient;
 
 	return (
 		<section className="mt-8">
-			<div className="mb-3 flex items-baseline justify-between">
-				<h2 className="text-sm font-semibold">Earlier today</h2>
-				<span className="text-muted-foreground text-xs">
-					{dayHours(earlier)}h so far
+			<h2 className="mb-3 text-sm font-semibold">Sessions by Client</h2>
+			{sections.length === 0 ? (
+				<p className="text-muted-foreground border-border bg-card rounded-xl border px-4 py-3 text-sm italic shadow-sm">
+					No Clients yet - add one under Clients and their section appears here.
+				</p>
+			) : (
+				<div className="space-y-2.5">
+					{sections.map((section) => (
+						<ClientCard
+							key={section.client.id}
+							flows={flows}
+							section={section}
+						/>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}
+
+function ClientCard({
+	flows,
+	section
+}: {
+	flows: LogFlows;
+	section: ClientSection;
+}) {
+	const { log } = flows;
+	const { client, sessions } = section;
+	// A Session still running has no hours yet - report the count alone rather
+	// than a misleading "0h".
+	const hours = dayHours(sessions);
+
+	return (
+		<div
+			data-slot="log-client-section"
+			className="border-border bg-card overflow-hidden rounded-xl border shadow-sm"
+		>
+			<div className="flex items-baseline justify-between gap-2 px-4 py-3">
+				<h3 className="min-w-0 truncate text-sm font-semibold">
+					{client.name}
+				</h3>
+				<span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+					{sessions.length === 0
+						? "no Sessions"
+						: `${plural(sessions.length, "Session")}${
+								hours === "0" ? "" : ` · ${hours}h`
+							}`}
 				</span>
 			</div>
-			<div className="border-border bg-card overflow-hidden rounded-xl border shadow-sm">
-				{earlier.length === 0 ? (
-					<p className="text-muted-foreground px-4 py-3 text-sm italic">
-						Nothing captured yet today.
-					</p>
-				) : (
-					<ul className="divide-border divide-y">
-						{earlier.map((session) => (
-							<li key={session.id}>
-								<button
-									className="hover:bg-accent flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left"
-									onClick={() => flows.editSession(session)}
-								>
-									<ClientAvatars names={log.participantNameList(session)} />
-									<div className="min-w-0 flex-1">
-										<div className="truncate text-sm font-medium">
-											{log.participantNames(session)}
-										</div>
-										<div className="text-muted-foreground text-xs tabular-nums">
-											{session.startTime} - {session.endTime}
-											{session.handoverType === "TRAVEL" &&
-												` · drove ${session.interClientDistance} km`}
-										</div>
+			{sessions.length > 0 && (
+				<ul className="divide-border border-border divide-y border-t">
+					{sessions.map((session) => (
+						<li key={session.id}>
+							<Button
+								variant="ghost"
+								className="h-auto w-full justify-start gap-3 rounded-none px-4 py-3 text-left font-normal"
+								onClick={() => flows.editSession(session)}
+							>
+								<ClientAvatars names={log.participantNameList(session)} />
+								<div className="min-w-0 flex-1">
+									<div className="truncate text-sm font-medium">
+										{formatDayKey(session.date, "EEE d MMM")}
 									</div>
-									<span className="text-muted-foreground text-xs tabular-nums">
-										{formatHours(sessionMinutes(session))}h
-									</span>
-								</button>
-							</li>
-						))}
-					</ul>
-				)}
-			</div>
-		</section>
+									<div className="text-muted-foreground text-xs tabular-nums">
+										{session.startTime} - {session.endTime ?? "open"}
+										{session.handoverType === "TRAVEL" &&
+											` · drove ${session.interClientDistance} km`}
+									</div>
+								</div>
+								<span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+									{session.endTime
+										? `${formatHours(sessionMinutes(session))}h`
+										: "running"}
+								</span>
+							</Button>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
 	);
 }
 
@@ -180,7 +228,7 @@ function WaitingToPromote({ flows }: { flows: LogFlows }) {
 			</div>
 			{log.openSession && (
 				<p className="text-muted-foreground mt-3 text-xs">
-					Today promotes once its open session ends - promotion is day-atomic.
+					Today promotes once its open Session ends - promotion is day-atomic.
 				</p>
 			)}
 		</section>
@@ -203,19 +251,20 @@ function PromoteDayCard({
 			<div className="min-w-0 flex-1">
 				<div className="text-sm font-medium">{label}</div>
 				<div className="text-muted-foreground truncate text-xs">
-					{sessions.length} session{sessions.length === 1 ? "" : "s"} ·{" "}
-					{dayHours(sessions)}h
+					{plural(sessions.length, "Session")} · {dayHours(sessions)}h
 				</div>
 				{sessions.map((session) => (
 					<SessionMeta key={session.id} session={session} />
 				))}
 			</div>
-			<button
-				className="border-border bg-card text-secondary-foreground hover:bg-accent cursor-pointer rounded-lg border px-3 py-1.5 text-sm font-medium"
+			<Button
+				variant="outline"
+				size="sm"
+				className="bg-card text-secondary-foreground"
 				onClick={() => flows.promoteDay(dateKey)}
 			>
 				Promote
-			</button>
+			</Button>
 		</div>
 	);
 }
@@ -242,14 +291,15 @@ function LogPage() {
 				<SyncStatus online={log.online} pending={log.queue.length} />
 				{log.hydrated && <CaptureConsole flows={flows} />}
 				<AutoEndNudge flows={flows} />
-				<EarlierToday flows={flows} />
+				<ClientSections flows={flows} />
 				<WaitingToPromote flows={flows} />
-				<button
-					className="text-muted-foreground hover:bg-accent mt-8 w-full cursor-pointer rounded-lg px-3 py-2 text-sm"
+				<Button
+					variant="ghost"
+					className="text-muted-foreground mt-8 w-full"
 					onClick={() => flows.editSession(null)}
 				>
-					+ Add a past session
-				</button>
+					+ Add a past Session
+				</Button>
 			</div>
 			{flows.dialogs}
 		</Layout>

--- a/src/server/api/activity-creation.ts
+++ b/src/server/api/activity-creation.ts
@@ -1,0 +1,162 @@
+// The one path that creates a batch of Activities and assembles them into a
+// Trip. Both the manual multi-activity form (`activity.bulkAdd`) and Log
+// Promotion (`log.promoteDay`) write through here, so the Activities, the
+// Trip, its inter-client legs, and the Provider Travel allocated onto each
+// Activity are always produced by the same code - no path can leave a Trip in
+// the database whose transit was never allocated.
+//
+// Callers keep the policy that is genuinely theirs: which Activities exist,
+// which of them carry the day's travel, and where the inter-client legs come
+// from - a manually entered day derives them from each Client's stored
+// distance, Promotion bills the distances captured in the field. Everything
+// downstream of those choices is shared.
+import { Prisma, type ActivityTransportType } from "@/generated/client";
+import {
+	standaloneTransitUpdates,
+	tripTransitUpdates,
+	type InterClientLeg
+} from "@/lib/trip-utils";
+import { applyTransitUpdates } from "@/server/api/transit";
+
+/** Anything Prisma accepts for a Decimal column. */
+type DecimalInput = number | string | Prisma.Decimal;
+
+export interface ActivityDraft {
+	clientId: string;
+	supportItemId: string;
+	date: Date;
+	startTime?: Date;
+	endTime?: Date;
+	/** Set on a group Activity - the rate divides by the participant count. */
+	groupSize?: number;
+	transitDistance?: DecimalInput;
+	transitDuration?: DecimalInput;
+	transportItems?: {
+		type: ActivityTransportType;
+		amount: DecimalInput;
+		note?: string | null;
+	}[];
+}
+
+// Everything trip-utils' allocation reads, plus the transport items callers
+// echo back to their own callers.
+const createdActivityArgs = {
+	include: {
+		transportItems: true,
+		client: {
+			select: {
+				distanceToClient: true,
+				travelTimeToClient: true,
+				transitRatePerKm: true
+			}
+		}
+	}
+} satisfies { include: Prisma.ActivityInclude };
+
+export type CreatedActivity = Prisma.ActivityGetPayload<
+	typeof createdActivityArgs
+>;
+
+/**
+ * How a batch's Provider Travel is handled once its Activities exist.
+ * `activities` are the ones that carry it - a group Session's mirrored
+ * Activities are left out, because travel bills once - and `legs` are the
+ * inter-client drives between them. Two or more travel-carrying Activities
+ * assemble a Trip; a lone one bills its home legs standalone.
+ */
+export interface TravelPlan {
+	activities: CreatedActivity[];
+	legs: InterClientLeg[];
+}
+
+/**
+ * Create `drafts` as Activities, then hand them to `planTravel` to decide the
+ * Trip and the transit allocation. Returning `null` from `planTravel` leaves
+ * every Activity's transit exactly as it was created - for a caller whose
+ * transit was entered by hand rather than derived.
+ *
+ * Runs entirely inside the caller's transaction: a batch either lands whole,
+ * with its Trip and allocated travel, or not at all.
+ */
+export async function createActivityBatch(
+	tx: Prisma.TransactionClient,
+	ownerId: string,
+	drafts: ActivityDraft[],
+	planTravel: (created: CreatedActivity[]) => TravelPlan | null
+): Promise<{ activities: CreatedActivity[]; tripId: string | null }> {
+	const activities: CreatedActivity[] = [];
+	for (const draft of drafts) {
+		// Written field by field rather than spread: a draft is built from user
+		// input, and the columns a batch create may set are this list only.
+		activities.push(
+			await tx.activity.create({
+				data: {
+					ownerId,
+					clientId: draft.clientId,
+					supportItemId: draft.supportItemId,
+					date: draft.date,
+					startTime: draft.startTime,
+					endTime: draft.endTime,
+					groupSize: draft.groupSize,
+					transitDistance: draft.transitDistance,
+					transitDuration: draft.transitDuration,
+					transportItems:
+						draft.transportItems && draft.transportItems.length > 0
+							? {
+									create: draft.transportItems.map((item) => ({
+										type: item.type,
+										amount: item.amount,
+										note: item.note
+									}))
+								}
+							: undefined
+				},
+				...createdActivityArgs
+			})
+		);
+	}
+
+	const plan = planTravel(activities);
+	if (!plan) return { activities, tripId: null };
+
+	// A day with two or more travel-carrying Activities is a Trip - even with no
+	// inter-client legs, since the home legs at either end still bill as one
+	// day's Provider Travel.
+	const isTrip = plan.activities.length >= 2;
+
+	let tripId: string | null = null;
+	if (isTrip) {
+		const trip = await tx.trip.create({
+			data: {
+				date: plan.activities[0].date,
+				ownerId,
+				activities: {
+					connect: plan.activities.map((activity) => ({ id: activity.id }))
+				},
+				interClientLegs: { create: plan.legs }
+			}
+		});
+		tripId = trip.id;
+	}
+
+	const updates = isTrip
+		? tripTransitUpdates(plan.activities, plan.legs)
+		: standaloneTransitUpdates(plan.activities);
+	await applyTransitUpdates(tx, updates);
+
+	// Keep the returned rows honest: they were read before the allocation wrote
+	// their transit, so fold the applied values back in.
+	const applied = new Map(updates.map((update) => [update.activityId, update]));
+	return {
+		activities: activities.map((activity) => {
+			const update = applied.get(activity.id);
+			if (!update) return activity;
+			return {
+				...activity,
+				transitDistance: new Prisma.Decimal(update.transitDistance),
+				transitDuration: new Prisma.Decimal(update.transitDuration)
+			};
+		}),
+		tripId
+	};
+}

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -4,6 +4,10 @@ import { checkActivityOverlap, formatOverlapError } from "@/lib/overlap-utils";
 import { baseListQueryInput } from "@/lib/trpc";
 import type { Prisma } from "@/generated/client";
 import { activitySchema } from "@/schema/activity-schema";
+import {
+	createActivityBatch,
+	type ActivityDraft
+} from "@/server/api/activity-creation";
 import { paginate } from "@/server/api/owned";
 import { authedProcedure, router } from "@/server/api/trpc";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
@@ -514,19 +518,23 @@ export const activityRouter = router({
 			}
 
 			// Parse and validate all activities
-			const parsedActivities = inputActivities.map((activity) => {
-				const { transportItems, ...activityData } = activity;
-				return {
-					...activityData,
-					startTime: activityData.startTime
-						? parseUtcTime(activityData.startTime)
+			const parsedActivities: ActivityDraft[] = inputActivities.map(
+				(activity) => ({
+					clientId: activity.clientId,
+					supportItemId: activity.supportItemId,
+					date: activity.date,
+					startTime: activity.startTime
+						? parseUtcTime(activity.startTime)
 						: undefined,
-					endTime: activityData.endTime
-						? parseUtcTime(activityData.endTime)
+					endTime: activity.endTime
+						? parseUtcTime(activity.endTime)
 						: undefined,
-					transportItems
-				};
-			});
+					groupSize: activity.groupSize,
+					transitDistance: activity.transitDistance || undefined,
+					transitDuration: activity.transitDuration || undefined,
+					transportItems: activity.transportItems
+				})
+			);
 
 			// Sort by start time for contiguity check
 			const sorted = [...parsedActivities].sort((a, b) => {
@@ -534,97 +542,49 @@ export const activityRouter = router({
 				return a.startTime.getTime() - b.startTime.getTime();
 			});
 
-			// Create all activities in a transaction
-			const createdActivities = await ctx.prisma.$transaction(
-				sorted.map((activity) =>
-					ctx.prisma.activity.create({
-						data: {
-							clientId: activity.clientId,
-							date: activity.date,
-							startTime: activity.startTime,
-							endTime: activity.endTime,
-							supportItemId: activity.supportItemId,
-							transitDistance: activity.transitDistance || undefined,
-							transitDuration: activity.transitDuration || undefined,
-							groupSize: activity.groupSize,
-							ownerId: ctx.session.user.id,
-							transportItems:
-								activity.transportItems && activity.transportItems.length > 0
-									? {
-											create: activity.transportItems.map((item) => ({
-												type: item.type,
-												amount: item.amount,
-												note: item.note
-											}))
-										}
-									: undefined
-						},
-						include: {
-							transportItems: true,
-							client: {
-								select: {
-									distanceToClient: true,
-									travelTimeToClient: true
-								}
-							}
-						}
-					})
-				)
-			);
+			const { activities, tripId } = await ctx.prisma.$transaction((tx) =>
+				createActivityBatch(tx, ctx.session.user.id, sorted, (created) => {
+					// A manually entered day only becomes a Trip when its Activities
+					// run back to back (end time equals the next start time); anything
+					// else keeps the transit that was entered by hand.
+					if (
+						!autoCreateTrip ||
+						created.length < 2 ||
+						!created.every((a) => a.startTime && a.endTime)
+					) {
+						return null;
+					}
 
-			// Check if activities are contiguous (end time equals next start time)
-			let tripId: string | null = null;
-			if (
-				autoCreateTrip &&
-				createdActivities.length >= 2 &&
-				createdActivities.every((a) => a.startTime && a.endTime)
-			) {
-				const isContiguous = createdActivities.every((activity, index) => {
-					if (index === 0) return true;
-					const prevActivity = createdActivities[index - 1];
-					if (!prevActivity.endTime || !activity.startTime) return false;
-					// Check if end time of previous equals start time of current
-					return (
-						format(utcDate(prevActivity.endTime), "HH:mm") ===
-						format(utcDate(activity.startTime), "HH:mm")
-					);
-				});
+					const isContiguous = created.every((activity, index) => {
+						if (index === 0) return true;
+						const prevActivity = created[index - 1];
+						if (!prevActivity.endTime || !activity.startTime) return false;
+						// Check if end time of previous equals start time of current
+						return (
+							format(utcDate(prevActivity.endTime), "HH:mm") ===
+							format(utcDate(activity.startTime), "HH:mm")
+						);
+					});
+					if (!isContiguous) return null;
 
-				if (isContiguous) {
-					// Create trip with inter-client legs
-					const interClientLegs = [];
-					for (let i = 0; i < createdActivities.length - 1; i++) {
-						const fromActivity = createdActivities[i];
-						const toActivity = createdActivities[i + 1];
-						interClientLegs.push({
-							fromActivityId: fromActivity.id,
+					// Inter-client legs of a manually entered day derive from each
+					// Client's stored distance - see ADR 0002.
+					const legs = [];
+					for (let i = 0; i < created.length - 1; i++) {
+						const toActivity = created[i + 1];
+						legs.push({
+							fromActivityId: created[i].id,
 							toActivityId: toActivity.id,
 							distance: Number(toActivity.client?.distanceToClient ?? 0),
 							duration: Number(toActivity.client?.travelTimeToClient ?? 0)
 						});
 					}
 
-					const trip = await ctx.prisma.trip.create({
-						data: {
-							date: createdActivities[0].date,
-							ownerId: ctx.session.user.id,
-							activities: {
-								connect: createdActivities.map((a) => ({ id: a.id }))
-							},
-							interClientLegs: {
-								create: interClientLegs
-							}
-						}
-					});
+					return { activities: created, legs };
+				})
+			);
 
-					tripId = trip.id;
-				}
-			}
-
-			return {
-				activities: createdActivities,
-				tripId
-			};
+			return { activities, tripId };
 		})
 });
 

--- a/src/server/api/routers/log-router.ts
+++ b/src/server/api/routers/log-router.ts
@@ -1,17 +1,12 @@
 import { parseUtcTime } from "@/lib/date-utils";
-import type {
-	ActivityTransportType,
-	Prisma,
-	PrismaClient
-} from "@/generated/client";
+import type { ActivityTransportType, PrismaClient } from "@/generated/client";
 import { ownedDb } from "@/server/api/owned";
 import { billableTravelDuration, defaultTravelDuration } from "@/lib/log-utils";
 import {
-	standaloneTransitUpdates,
-	tripTransitUpdates,
-	type TransitUpdate
-} from "@/lib/trip-utils";
-import { applyTransitUpdates } from "@/server/api/transit";
+	createActivityBatch,
+	type ActivityDraft,
+	type CreatedActivity
+} from "@/server/api/activity-creation";
 import {
 	END_AFTER_START_MESSAGE,
 	OPEN_SESSION_EDIT_MESSAGE,
@@ -25,6 +20,16 @@ import { authedProcedure, router } from "@/server/api/trpc";
 import { TRPCError, inferRouterOutputs } from "@trpc/server";
 import { z } from "zod";
 
+// A Session's participants have no natural order - the join table is keyed by
+// (Session, Client) - so every read orders them by clientId. Promotion treats
+// the first as the Session's primary participant (the Activity that carries
+// the captured transport and joins the Trip), and that choice has to be the
+// same on every read of the same Session.
+const participantsOrdered = {
+	select: { clientId: true, client: { select: { name: true } } },
+	orderBy: { clientId: "asc" as const }
+};
+
 const workSessionSelect = {
 	id: true,
 	date: true,
@@ -35,9 +40,7 @@ const workSessionSelect = {
 	interClientDistance: true,
 	interClientDuration: true,
 	updatedAt: true,
-	participants: {
-		select: { clientId: true, client: { select: { name: true } } }
-	},
+	participants: participantsOrdered,
 	transportItems: {
 		select: { id: true, type: true, amount: true, note: true }
 	}
@@ -46,43 +49,42 @@ const workSessionSelect = {
 type LogContext = {
 	prisma: PrismaClient;
 	owned: ReturnType<typeof ownedDb>;
+	session: { user: { id: string } };
 };
 
 const participantsCreate = (clientIds: string[]) => ({
 	create: clientIds.map((clientId) => ({ clientId }))
 });
 
+/**
+ * Last-write-wins on `updatedAt`: a capture that was tapped before the version
+ * already stored is a delayed offline replay, and applying it would undo a
+ * newer edit of the same Session. Every stamped write checks this and hands
+ * back the row as it actually stands instead of failing - the tap is simply
+ * the older one.
+ */
+const isStale = (session: { updatedAt: Date }, tappedAt: Date | undefined) =>
+	tappedAt !== undefined && session.updatedAt > tappedAt;
+
+/** The Session as it currently stands - what a dropped stale write returns. */
+async function readBack(ctx: LogContext, id: string) {
+	const current = await ctx.owned.workSession.findFirst({
+		where: { id },
+		select: workSessionSelect
+	});
+	if (!current) throw new TRPCError({ code: "NOT_FOUND" });
+	return current;
+}
+
 // One participant row = solo, N rows = group; the composition picks the
 // default Support Item and gives the mirrored Activities their groupSize.
 const isGroupSession = (session: { participants: unknown[] }) =>
 	session.participants.length > 1;
 
-// What promoteDay needs back from each created Activity: identity for the
-// Trip, and the TripActivity shape trip-utils' transit allocation reads.
-const promotedActivitySelect = {
-	id: true,
-	startTime: true,
-	endTime: true,
-	transitDistance: true,
-	transitDuration: true,
-	client: {
-		select: {
-			distanceToClient: true,
-			travelTimeToClient: true,
-			transitRatePerKm: true
-		}
-	}
-} satisfies Prisma.ActivitySelect;
-
-type PromotedActivity = Prisma.ActivityGetPayload<{
-	select: typeof promotedActivitySelect;
-}>;
-
 // Shared by recordTrip (a DISTANCE item in km) and recordCost (flat Transport
 // Expenses). Idempotent on the client-generated item id for offline replays.
 async function createTransportItem(
 	ctx: LogContext,
-	ownerId: string,
 	item: {
 		id?: string;
 		workSessionId: string;
@@ -95,7 +97,7 @@ async function createTransportItem(
 
 	if (item.id) {
 		const existing = await ctx.prisma.workSessionTransportItem.findFirst({
-			where: { id: item.id, workSession: { ownerId } },
+			where: { id: item.id, workSession: { ownerId: ctx.session.user.id } },
 			select: { id: true, type: true, amount: true, note: true }
 		});
 		// A replayed capture that already synced is a no-op, never a duplicate.
@@ -151,21 +153,12 @@ async function splitAtPivot(
 			endTime: true,
 			ownerId: true,
 			updatedAt: true,
-			participants: { select: { clientId: true } }
+			participants: participantsOrdered
 		}
 	});
 	if (!session) throw new TRPCError({ code: "NOT_FOUND" });
 
-	// Last-write-wins: a delayed offline split replay never clobbers a newer
-	// edit of the Session it would close.
-	if (input.updatedAt && session.updatedAt > input.updatedAt) {
-		const current = await ctx.owned.workSession.findFirst({
-			where: { id: session.id },
-			select: workSessionSelect
-		});
-		if (!current) throw new TRPCError({ code: "NOT_FOUND" });
-		return current;
-	}
+	if (isStale(session, input.updatedAt)) return readBack(ctx, session.id);
 
 	if (session.endTime) {
 		throw new TRPCError({
@@ -287,14 +280,7 @@ export const logRouter = router({
 			});
 			if (!session) throw new TRPCError({ code: "NOT_FOUND" });
 
-			// Last-write-wins: a delayed offline end replay never clobbers a
-			// newer edit of the same Session.
-			if (input.updatedAt && session.updatedAt > input.updatedAt) {
-				return ctx.owned.workSession.findFirst({
-					where: { id: input.id },
-					select: workSessionSelect
-				});
-			}
+			if (isStale(session, input.updatedAt)) return readBack(ctx, input.id);
 
 			const endTime = parseUtcTime(input.endTime);
 			if (endTime <= session.startTime) {
@@ -329,12 +315,8 @@ export const logRouter = router({
 				throw new TRPCError({ code: "NOT_FOUND" });
 			}
 
-			// Last-write-wins: a stale offline replay never clobbers a newer edit.
-			if (existing && input.updatedAt && existing.updatedAt > input.updatedAt) {
-				return ctx.owned.workSession.findFirst({
-					where: { id: input.id },
-					select: workSessionSelect
-				});
+			if (existing && isStale(existing, input.updatedAt)) {
+				return readBack(ctx, input.id);
 			}
 
 			// At most one Open Session per Provider: an edit that leaves this
@@ -479,14 +461,8 @@ export const logRouter = router({
 
 			const isTravel = input.handoverType === "TRAVEL";
 
-			// Last-write-wins: a delayed offline handover replay never clobbers a
-			// newer edit of the same Session.
-			const stale = input.updatedAt && session.updatedAt > input.updatedAt;
-			const workSession = stale
-				? await ctx.owned.workSession.findFirst({
-						where: { id: session.id },
-						select: workSessionSelect
-					})
+			const workSession = isStale(session, input.updatedAt)
+				? await readBack(ctx, session.id)
 				: await ctx.prisma.workSession.update({
 						where: { id: session.id },
 						data: {
@@ -500,7 +476,6 @@ export const logRouter = router({
 						},
 						select: workSessionSelect
 					});
-			if (!workSession) throw new TRPCError({ code: "NOT_FOUND" });
 
 			// The gap between the two stamped times is known here, so surface the
 			// pre-fill and the fits-the-gap warning to the capture UI. Warn, never
@@ -535,7 +510,7 @@ export const logRouter = router({
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
-			return createTransportItem(ctx, ctx.session.user.id, {
+			return createTransportItem(ctx, {
 				id: input.id,
 				workSessionId: input.workSessionId,
 				type: "DISTANCE",
@@ -555,7 +530,7 @@ export const logRouter = router({
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
-			return createTransportItem(ctx, ctx.session.user.id, input);
+			return createTransportItem(ctx, input);
 		}),
 
 	// Day-atomic Promotion: every captured Session becomes a Pending Activity
@@ -584,7 +559,7 @@ export const logRouter = router({
 					handoverType: true,
 					interClientDistance: true,
 					interClientDuration: true,
-					participants: { select: { clientId: true } },
+					participants: participantsOrdered,
 					transportItems: {
 						select: { type: true, amount: true, note: true }
 					}
@@ -692,96 +667,75 @@ export const logRouter = router({
 				});
 			}
 
-			return ctx.prisma.$transaction(async (tx) => {
-				const activityIds: string[] = [];
-				const primaryBySessionId = new Map<string, PromotedActivity>();
+			// One Activity per participant, in Session order. The primary
+			// participant - the first by the deterministic participant order - is
+			// the one that carries the Session's transport and joins the Trip.
+			const drafts: ActivityDraft[] = [];
+			const primarySessionIdByDraft = new Map<number, string>();
+			for (const session of sessions) {
+				const groupSize = isGroupSession(session)
+					? session.participants.length
+					: undefined;
+				const supportItemId = supportItemIdBySession.get(session.id);
+				if (!supportItemId) continue; // unreachable: seeded above
 
-				for (const session of sessions) {
-					const groupSize = isGroupSession(session)
-						? session.participants.length
-						: undefined;
-
-					const supportItemId = supportItemIdBySession.get(session.id);
-					if (!supportItemId) continue; // unreachable: seeded above
-
-					for (const [index, participant] of session.participants.entries()) {
-						const isPrimary = index === 0;
-						const activity = await tx.activity.create({
-							data: {
-								ownerId: ctx.session.user.id,
-								clientId: participant.clientId,
-								supportItemId,
-								date: input.date,
-								startTime: session.startTime,
-								endTime: session.endTime,
-								groupSize,
-								// The Session's trips and costs bill once, on the
-								// primary participant's Activity - mirrors share the
-								// support time, not the transport.
-								transportItems:
-									isPrimary && session.transportItems.length > 0
-										? {
-												create: session.transportItems.map((item) => ({
-													type: item.type,
-													amount: item.amount,
-													note: item.note
-												}))
-											}
-										: undefined
-							},
-							select: promotedActivitySelect
-						});
-						activityIds.push(activity.id);
-						if (isPrimary) primaryBySessionId.set(session.id, activity);
-					}
+				for (const [index, participant] of session.participants.entries()) {
+					const isPrimary = index === 0;
+					if (isPrimary) primarySessionIdByDraft.set(drafts.length, session.id);
+					drafts.push({
+						clientId: participant.clientId,
+						supportItemId,
+						date: input.date,
+						startTime: session.startTime,
+						endTime: session.endTime ?? undefined,
+						groupSize,
+						// The Session's trips and costs bill once, on the primary
+						// participant's Activity - mirrors share the support time, not
+						// the transport.
+						transportItems: isPrimary ? session.transportItems : undefined
+					});
 				}
+			}
 
-				const primaries = [...primaryBySessionId.values()];
-
+			return ctx.prisma.$transaction(async (tx) => {
 				// Provider Travel bills once per Session, on the primary Activity:
 				// mirrors never join the Trip. Home legs derive from the Clients'
 				// stored distances through the same allocation engine as manually
 				// assembled days.
-				let tripId: string | null = null;
-				let transitUpdates: TransitUpdate[];
-				if (primaries.length >= 2) {
-					const legs = legPlans.flatMap((leg) => {
-						const from = primaryBySessionId.get(leg.fromSessionId);
-						const to = primaryBySessionId.get(leg.toSessionId);
-						if (!from || !to) return []; // unreachable: legs link loaded sessions
-						return [
-							{
-								fromActivityId: from.id,
-								toActivityId: to.id,
-								distance: leg.distance,
-								duration: leg.duration
-							}
-						];
-					});
+				const { activities, tripId } = await createActivityBatch(
+					tx,
+					ctx.session.user.id,
+					drafts,
+					(created) => {
+						const primaryBySessionId = new Map<string, CreatedActivity>();
+						created.forEach((activity, index) => {
+							const sessionId = primarySessionIdByDraft.get(index);
+							if (sessionId) primaryBySessionId.set(sessionId, activity);
+						});
 
-					const trip = await tx.trip.create({
-						data: {
-							date: input.date,
-							ownerId: ctx.session.user.id,
-							activities: {
-								connect: primaries.map((activity) => ({ id: activity.id }))
-							},
-							interClientLegs: { create: legs }
-						}
-					});
-					tripId = trip.id;
-					transitUpdates = tripTransitUpdates(primaries, legs);
-				} else {
-					transitUpdates = standaloneTransitUpdates(primaries);
-				}
+						const legs = legPlans.flatMap((leg) => {
+							const from = primaryBySessionId.get(leg.fromSessionId);
+							const to = primaryBySessionId.get(leg.toSessionId);
+							if (!from || !to) return []; // unreachable: legs link loaded sessions
+							return [
+								{
+									fromActivityId: from.id,
+									toActivityId: to.id,
+									distance: leg.distance,
+									duration: leg.duration
+								}
+							];
+						});
 
-				await applyTransitUpdates(tx, transitUpdates);
+						return { activities: [...primaryBySessionId.values()], legs };
+					}
+				);
 
 				await tx.workSession.deleteMany({
 					where: { id: { in: sessions.map((session) => session.id) } }
 				});
 
-				return { activityIds, tripId };
+				return { activityIds: activities.map((a) => a.id), tripId };
 			});
 		}),
 

--- a/src/server/api/test/log-promotion.integration.test.ts
+++ b/src/server/api/test/log-promotion.integration.test.ts
@@ -168,6 +168,49 @@ describe("log.promoteDay", () => {
 		expect(mirror?.transitDistance).toBeNull();
 	});
 
+	test("the primary participant of a group Session does not depend on capture order", async () => {
+		const { owner } = await createProviderFixture();
+		const caller = callerFor(owner);
+
+		// Explicit ids so the participant order the router pins is knowable: the
+		// Session is captured with the participants the other way round, and
+		// Promotion still bills the transport on the id-ordered first one rather
+		// than on whichever row the database happens to hand back.
+		const [early, late] = await Promise.all(
+			[
+				{ id: "client-aaa", name: "Zoe" },
+				{ id: "client-zzz", name: "Adam" }
+			].map((data) =>
+				prisma.client.create({
+					data: { ...data, ownerId: owner.id, distanceToClient: 3 }
+				})
+			)
+		);
+
+		const group = await caller.log.start({
+			date: DAY,
+			startTime: "09:00",
+			clientIds: [late.id, early.id]
+		});
+		await caller.log.recordTrip({ workSessionId: group.id, distance: 5 });
+		await caller.log.end({ id: group.id, endTime: "11:00" });
+
+		await caller.log.promoteDay({ date: DAY });
+
+		const activities = await prisma.activity.findMany({
+			where: { ownerId: owner.id },
+			include: { transportItems: true }
+		});
+		const withTransport = activities.filter((a) => a.transportItems.length > 0);
+		expect(withTransport).toHaveLength(1);
+		expect(withTransport[0].clientId).toBe(early.id);
+		// Home travel bills once, on that same Activity.
+		expect(Number(withTransport[0].transitDistance)).toBe(6);
+		expect(
+			activities.find((a) => a.clientId === late.id)?.transitDistance
+		).toBeNull();
+	});
+
 	test("an add-participant day splits per composition and the pivot boundary promotes cleanly with no invented leg", async () => {
 		const { owner, soloItem, groupItem, clients } =
 			await createProviderFixture();

--- a/src/server/api/test/trip-lifecycle.integration.test.ts
+++ b/src/server/api/test/trip-lifecycle.integration.test.ts
@@ -215,3 +215,116 @@ describe("trip.delete", () => {
 		expect(await prisma.trip.findUnique({ where: { id: trip.id } })).toBeNull();
 	});
 });
+
+// bulkAdd is the other path that assembles a Trip - the manual multi-activity
+// form. It shares Promotion's creation path, so a day it links as a Trip has
+// its Provider Travel allocated by the same engine as trip.create.
+describe("activity.bulkAdd", () => {
+	test("a contiguous day linked as a Trip allocates transit onto its Activities", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const { supportItem, clients } = await createTripFixture(owner);
+		const [first, second] = clients;
+
+		const { tripId, activities } = await caller.activity.bulkAdd({
+			activities: [
+				{
+					clientId: first.id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-02-01"),
+					startTime: "09:00",
+					endTime: "10:00"
+				},
+				{
+					clientId: second.id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-02-01"),
+					startTime: "10:00",
+					endTime: "11:00"
+				}
+			],
+			autoCreateTrip: true
+		});
+
+		expect(tripId).not.toBeNull();
+
+		// Legs of a manually entered day derive from each Client's stored
+		// distance: 8 km / 15 min out to the second Client.
+		const trip = await prisma.trip.findUniqueOrThrow({
+			where: { id: tripId as string },
+			include: { interClientLegs: true }
+		});
+		expect(trip.interClientLegs).toHaveLength(1);
+		expect(Number(trip.interClientLegs[0].distance)).toBe(8);
+
+		const persisted = await fetchTripActivities(activities.map((a) => a.id));
+		const expected = calculateTripTransit(
+			persisted.map((activity) => ({
+				...activity,
+				transitDistance: null,
+				transitDuration: null
+			})),
+			trip.interClientLegs
+		);
+		for (const activity of persisted) {
+			expect(Number(activity.transitDistance)).toBe(
+				expected.get(activity.id)?.transitDistance
+			);
+			expect(Number(activity.transitDuration)).toBe(
+				expected.get(activity.id)?.transitDuration
+			);
+		}
+		// The first Client's drive out, the second's leg in plus the drive home -
+		// not the zeroes an unallocated Trip would leave behind.
+		const byClient = new Map(
+			(
+				await prisma.activity.findMany({
+					where: { id: { in: activities.map((a) => a.id) } },
+					select: { clientId: true, transitDistance: true }
+				})
+			).map((a) => [a.clientId, Number(a.transitDistance)])
+		);
+		expect(byClient.get(first.id)).toBe(5);
+		expect(byClient.get(second.id)).toBe(8 + 8);
+	});
+
+	test("a non-contiguous day forms no Trip and keeps hand-entered transit", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const { supportItem, clients } = await createTripFixture(owner);
+
+		const { tripId, activities } = await caller.activity.bulkAdd({
+			activities: [
+				{
+					clientId: clients[0].id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-02-01"),
+					startTime: "09:00",
+					endTime: "10:00",
+					transitDistance: "42",
+					transitDuration: "17"
+				},
+				{
+					clientId: clients[1].id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-02-01"),
+					startTime: "13:00",
+					endTime: "14:00"
+				}
+			],
+			autoCreateTrip: true
+		});
+
+		expect(tripId).toBeNull();
+		expect(await prisma.trip.count({ where: { ownerId: owner.id } })).toBe(0);
+
+		const entered = await prisma.activity.findFirstOrThrow({
+			where: {
+				id: { in: activities.map((a) => a.id) },
+				clientId: clients[0].id
+			}
+		});
+		expect(Number(entered.transitDistance)).toBe(42);
+		expect(Number(entered.transitDuration)).toBe(17);
+	});
+});


### PR DESCRIPTION
Follow-up review pass on the field-capture Log (#464), now that it is merged. Two axes: does the code match what the issue asked for, and does it follow the repo's conventions.

## Spec findings

**Promotion no longer reimplements batch Activity creation.** The issue asked Promotion to reuse the existing batch creation path "so Activities + Trip + InterClientLeg are produced by one code path"; `promoteDay` had grown its own `activity.create` loop, its own `trip.create`, and its own validation. New `src/server/api/activity-creation.ts` holds that one path, and both `activity.bulkAdd` and `log.promoteDay` write through it. Each caller keeps only the policy that is genuinely its own, via a single `planTravel` callback: which Activities carry the day's travel (a group Session's mirrors do not) and where the inter-client legs come from - a manually entered day derives them from each Client's stored distance, Promotion bills the distances captured in the field.

This surfaced a real bug: `bulkAdd` created a Trip and **never allocated transit**, unlike every other trip-assembling path. Manually entered batch days now get their Provider Travel allocated. Covered by two new integration tests, including that a non-contiguous day still forms no Trip and keeps hand-entered transit untouched.

**The primary participant of a group Session is now deterministic.** Every `WorkSessionParticipant` read orders by `clientId`, and the offline store sorts participants the same way, so both sides agree on which mirrored Activity carries the Session's transport and joins the Trip. Display names sort alphabetically instead, so ordering by opaque id does not leak into the UI. In practice the ordering was already being supplied by the composite-PK index scan, so this closes a missing guarantee rather than an observed defect.

**Stories 19 and 20 are implemented.** The Log tab is now organised as persistent per-Client sections - one per Client, kept even when empty as standing scaffolding, with a group Session appearing under each participant - matching `CONTEXT.md` and the `listByClient` shape it already returned. New e2e test covers both stories.

**IDs stay UUIDs.** The issue said "a cuid minted on-device"; the column is a plain string and the requirement is a stable client-generated id, so this keeps `crypto.randomUUID()` with a comment rather than adding a cuid2 dependency for the id's format.

### Findings deliberately not actioned

- **`listByDay` is not dead code.** It is the read seam for 26 assertions across the log integration suite and a documented query in the API contract.
- **Auto-ending at 23:59 stays.** It was a deliberate decision, `CONTEXT.md` records it as a domain rule, and the story-24 nudge sits on top of it.
- **No lib-level promotion helper.** The repo's Testing Decisions for this feature state the travel-time helper is "the only logic extracted below the router seam", which overrides the general preference for unit-testable policy modules. The shared creation module shrank `log-router.ts` from 824 to 693 lines anyway.
- **`log-utils.ts` placement is correct** - `src/lib/*-utils.ts` is the convention for shared pure helpers; `src/lib/log/` is the offline-store package.

## Standards findings

- **Domain vocabulary**: Session and Log capitalised throughout the user-facing copy, per the `CONTEXT.md` glossary.
- **Dash rule**: en dash and ellipsis characters replaced with plain `-` and `...`.
- **Duplicated code**: the four-times-repeated last-write-wins guard extracted to `isStale`/`readBack`; `responsive-dialog`'s five if/else parts collapsed into one `responsivePart` factory; a shared `WarningNote` replaces four hand-rolled amber blocks.
- **De-facto standards**: all 16 raw `<button>` elements converted to the `Button` component, with the four repeated two-line console tiles becoming one `CaptureTile`.
- **Feature envy**: `log.clientName(id)` replaces a fabricated Session object used to read a single name.
- Redundant `ownerId` parameter dropped from `createTransportItem`.

## Test coverage

New `src/lib/log/log-store.test.ts` - 17 co-located tests over the 684 lines of offline/last-write-wins logic that previously had no unit coverage: capture guards, tap-time stamping, queueing, the pivot split, participant ordering, auto-end at 23:59 with its nudge, and IndexedDB persistence.

## UI

Screenshotted the Log at phone and laptop width, which caught two pixel issues: `Button`'s `justify-center` was vertically centring the shorter capture tile so the two labels did not line up, and a Client section whose only Session was still running read "1 Session · 0h".

## Verification

type-check clean, prettier clean, lint 0 errors (5 pre-existing React Compiler warnings in untouched form files), 210 unit tests, 135 integration tests, 26 e2e tests - all passing. No Prisma migration needed: the participant fix is an `orderBy`, not a schema change.

## Noted for later

`activity.bulkAdd` silently drops `itemDistance` and a caller-supplied `id`, both real Activity columns its input schema accepts. This PR preserves that behaviour exactly (the batch write is an explicit field list rather than a spread), but the `itemDistance` drop looks like a genuine pre-existing bug - the schema permits an activity with `itemDistance` and no times, which would save with no distance. Worth its own issue.