### PR TITLE
fix: Provider Travel on single Activities, and the edit form overwriting saved fields

### DIFF
--- a/e2e/activities.test.ts
+++ b/e2e/activities.test.ts
@@ -1,3 +1,4 @@
+import prisma from "@/server/prisma";
 import { expect, test } from "@playwright/test";
 import {
 	createDefaultSupportItem,
@@ -10,6 +11,10 @@ import {
 test("Can create activity", async ({ page }) => {
 	const client = await createRandomClient();
 	await createDefaultSupportItem();
+	await prisma.client.update({
+		where: { id: client.id },
+		data: { distanceToClient: 40, travelTimeToClient: 55 }
+	});
 
 	await page.goto("/dashboard");
 
@@ -21,6 +26,16 @@ test("Can create activity", async ({ page }) => {
 	await page.getByRole("button", { name: "Save all" }).click();
 
 	await waitForAlert(page, "saved");
+
+	// A day of one activity forms no trip, so it bills the return trip home →
+	// client → home with each leg capped at 30 minutes - it used to be saved with
+	// no provider travel at all.
+	const saved = await prisma.activity.findFirstOrThrow({
+		where: { clientId: client.id }
+	});
+	expect(saved.tripId).toBeNull();
+	expect(Number(saved.transitDistance)).toBe(80);
+	expect(Number(saved.transitDuration)).toBe(60);
 });
 
 test("Can edit activity", async ({ page }) => {
@@ -45,6 +60,88 @@ test("Can edit activity", async ({ page }) => {
 	await page.getByRole("button", { name: "Update" }).click();
 	await waitForAlert(page, "activity updated");
 	await expect(page).toHaveURL(`/dashboard/activities/${activity.id}`);
+});
+
+test("Editing an activity keeps its support item, provider travel and transport", async ({
+	page
+}) => {
+	const client = await createRandomClient();
+	// A default support item the activity is deliberately NOT billed under, and a
+	// client whose stored travel differs from the activity's — both used to be
+	// written over the loaded activity the moment the edit form mounted.
+	await createDefaultSupportItem();
+	const supportItem = await createRandomSupportItem();
+	await prisma.client.update({
+		where: { id: client.id },
+		data: { distanceToClient: 40, travelTimeToClient: 55 }
+	});
+	const activity = await createRandomActivity(
+		client.id,
+		supportItem.id,
+		{ startTime: "11:00", endTime: "12:00" },
+		{
+			transitDistance: 12.5,
+			transitDuration: 20,
+			transportItems: [
+				{ type: "DISTANCE", amount: 8.4 },
+				{ type: "PARKING", amount: 6.5, note: "carpark" }
+			]
+		}
+	);
+
+	// Reached through the detail page, so the form's post-save `router.back()`
+	// lands on a real history entry.
+	await page.goto(`/dashboard/activities/${activity.id}`);
+	await page.getByRole("link", { name: "Edit" }).click();
+
+	await page.getByRole("button", { name: "Advanced Options" }).click();
+
+	await expect(page.getByLabel("Transit Distance")).toHaveValue("12.5");
+	await expect(page.getByLabel("Transit Duration")).toHaveValue("20");
+	await expect(page.getByLabel("Activity Based Transport")).toHaveValue("8.4");
+	// The parking row, in the parking / tolls editor
+	await expect(page.getByPlaceholder("0.00")).toHaveValue("6.5");
+	await expect(
+		page.getByRole("combobox", { name: /Support Item/ })
+	).toContainText(supportItem.description);
+
+	await page.getByLabel("End Time").fill("12:30");
+	await page.getByRole("button", { name: "Update" }).click();
+	await waitForAlert(page, "activity updated");
+
+	const saved = await prisma.activity.findUniqueOrThrow({
+		where: { id: activity.id },
+		include: { transportItems: true }
+	});
+
+	expect(saved.supportItemId).toBe(supportItem.id);
+	expect(saved.transitDistance?.toString()).toBe("12.5");
+	expect(saved.transitDuration?.toString()).toBe("20");
+	expect(
+		saved.transportItems.map((item) => `${item.type}:${item.amount}`).sort()
+	).toEqual(["DISTANCE:8.4", "PARKING:6.5"]);
+});
+
+test("A new activity prefills the client's return trip as provider travel", async ({
+	page
+}) => {
+	const client = await createRandomClient();
+	await createDefaultSupportItem();
+	await prisma.client.update({
+		where: { id: client.id },
+		data: { distanceToClient: 40, travelTimeToClient: 55 }
+	});
+
+	await page.goto("/dashboard/activities/create");
+
+	await page.getByRole("combobox", { name: "Client" }).click();
+	await page.getByRole("option", { name: client.name }).click();
+	await page.getByRole("button", { name: "Advanced Options" }).click();
+
+	// Home → client → home: 40 km each way, and 55 minutes each way capped at the
+	// 30-minute Travel Time Cap per leg.
+	await expect(page.getByLabel("Transit Distance")).toHaveValue("80");
+	await expect(page.getByLabel("Transit Duration")).toHaveValue("60");
 });
 
 test("Activity detail shows the billing breakdown", async ({ page }) => {

--- a/e2e/test-utils.ts
+++ b/e2e/test-utils.ts
@@ -1,4 +1,5 @@
 import { getTotalCostOfActivities } from "@/lib/activity-utils";
+import type { ActivityTransportType } from "@/schema/activity-schema";
 import prisma from "@/server/prisma";
 import { Page } from "@playwright/test";
 import { randomUUID } from "crypto";
@@ -378,7 +379,16 @@ export async function createRealisticInvoice() {
 export async function createRandomActivity(
 	clientId: string,
 	supportItemId: string,
-	times?: { startTime: string; endTime: string }
+	times?: { startTime: string; endTime: string },
+	billing?: {
+		transitDistance?: number;
+		transitDuration?: number;
+		transportItems?: {
+			type: ActivityTransportType;
+			amount: number;
+			note?: string;
+		}[];
+	}
 ) {
 	const startTime = times?.startTime ?? "09:15";
 	const endTime = times?.endTime ?? "10:00";
@@ -394,6 +404,11 @@ export async function createRandomActivity(
 			// AEST), which can wrap a same-day range into a reversed one.
 			startTime: new Date(`1970-01-01T${startTime}:00.000Z`),
 			endTime: new Date(`1970-01-01T${endTime}:00.000Z`),
+			transitDistance: billing?.transitDistance,
+			transitDuration: billing?.transitDuration,
+			transportItems: billing?.transportItems
+				? { create: billing.transportItems }
+				: undefined,
 			ownerId: testUser.id
 		}
 	});

--- a/src/components/activities/activity-form-model.test.ts
+++ b/src/components/activities/activity-form-model.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+	activityFormDefaults,
+	hydrateTransportItems,
+	mergeTransportItems,
+	otherTransportItems,
+	standaloneTravelDefaults,
+	toActivityPayload
+} from "./activity-form-model";
+
+// The wire shape: Prisma Decimals arrive as strings, times as UTC-anchored Dates.
+const EXISTING = {
+	date: new Date("2026-07-20T00:00:00Z"),
+	client: { id: "client-1" },
+	supportItem: { id: "item-1" },
+	startTime: new Date("1970-01-01T09:30:00Z"),
+	endTime: new Date("1970-01-01T11:00:00Z"),
+	itemDistance: null,
+	transitDistance: "12.5",
+	transitDuration: "20",
+	groupSize: 3,
+	transportItems: [
+		{ type: "DISTANCE" as const, amount: "8.4" },
+		{ type: "PARKING" as const, amount: "6.5", note: "carpark" }
+	]
+};
+
+describe("activityFormDefaults", () => {
+	it("loads every saved field of an existing activity", () => {
+		expect(activityFormDefaults(EXISTING)).toEqual({
+			date: EXISTING.date,
+			clientId: "client-1",
+			supportItemId: "item-1",
+			startTime: "09:30",
+			endTime: "11:00",
+			itemDistance: undefined,
+			transitDistance: "12.5",
+			transitDuration: "20",
+			groupSize: 3,
+			transportItems: [
+				{ type: "DISTANCE", amount: 8.4 },
+				{ type: "PARKING", amount: 6.5, note: "carpark" }
+			]
+		});
+	});
+
+	it("keeps a zero transit distance rather than reading it as absent", () => {
+		const defaults = activityFormDefaults({
+			...EXISTING,
+			transitDistance: "0"
+		});
+
+		expect(defaults.transitDistance).toBe("0");
+	});
+
+	it("starts a new activity empty, with today's date and a zero km row", () => {
+		const defaults = activityFormDefaults();
+
+		expect(defaults.clientId).toBe("");
+		expect(defaults.supportItemId).toBe("");
+		expect(defaults.startTime).toBe("");
+		expect(defaults.transitDistance).toBe("");
+		expect(defaults.groupSize).toBeUndefined();
+		expect(defaults.transportItems).toEqual([{ type: "DISTANCE", amount: 0 }]);
+	});
+});
+
+describe("standaloneTravelDefaults", () => {
+	it("prefills the return trip, not one leg of it", () => {
+		expect(
+			standaloneTravelDefaults({
+				distanceToClient: "12.5",
+				travelTimeToClient: "20"
+			})
+		).toEqual({ transitDistance: "25", transitDuration: "40" });
+	});
+
+	it("caps each leg's minutes at the travel time cap", () => {
+		expect(
+			standaloneTravelDefaults({
+				distanceToClient: "40",
+				travelTimeToClient: "45"
+			})
+		).toEqual({ transitDistance: "80", transitDuration: "60" });
+	});
+
+	it("leaves a field blank when the client has no stored value", () => {
+		expect(
+			standaloneTravelDefaults({
+				distanceToClient: null,
+				travelTimeToClient: "20"
+			})
+		).toEqual({ transitDistance: "", transitDuration: "40" });
+
+		expect(standaloneTravelDefaults(null)).toEqual({
+			transitDistance: "",
+			transitDuration: ""
+		});
+	});
+});
+
+describe("hydrateTransportItems", () => {
+	it("puts a zero km row first when there is no stored transport", () => {
+		expect(hydrateTransportItems()).toEqual([{ type: "DISTANCE", amount: 0 }]);
+		expect(hydrateTransportItems([])).toEqual([
+			{ type: "DISTANCE", amount: 0 }
+		]);
+	});
+
+	it("sums multiple stored distance rows into the single km field", () => {
+		expect(
+			hydrateTransportItems([
+				{ type: "DISTANCE", amount: "5" },
+				{ type: "TOLL", amount: "4" },
+				{ type: "DISTANCE", amount: "2.5" }
+			])
+		).toEqual([
+			{ type: "DISTANCE", amount: 7.5 },
+			{ type: "TOLL", amount: 4, note: undefined }
+		]);
+	});
+});
+
+describe("otherTransportItems / mergeTransportItems", () => {
+	const hydrated = hydrateTransportItems(EXISTING.transportItems);
+
+	it("exposes only the non-distance rows to the editor", () => {
+		expect(otherTransportItems(hydrated)).toEqual([
+			{ type: "PARKING", amount: 6.5, note: "carpark" }
+		]);
+	});
+
+	it("keeps the km row at index 0 when the editor writes back", () => {
+		const merged = mergeTransportItems(hydrated, [{ type: "TOLL", amount: 3 }]);
+
+		expect(merged).toEqual([
+			{ type: "DISTANCE", amount: 8.4 },
+			{ type: "TOLL", amount: 3 }
+		]);
+	});
+
+	it("keeps a km row at index 0 even with nothing to merge into", () => {
+		expect(mergeTransportItems(undefined, [])).toEqual([
+			{ type: "DISTANCE", amount: 0 }
+		]);
+	});
+});
+
+describe("toActivityPayload", () => {
+	const values = activityFormDefaults(EXISTING);
+
+	it("round-trips the transport, transit and group fields of an hourly item", () => {
+		const payload = toActivityPayload(values, "HOUR");
+
+		expect(payload).toMatchObject({
+			startTime: "09:30",
+			endTime: "11:00",
+			itemDistance: undefined,
+			transitDistance: "12.5",
+			transitDuration: "20",
+			groupSize: 3,
+			transportItems: [
+				{ type: "DISTANCE", amount: 8.4 },
+				{ type: "PARKING", amount: 6.5, note: "carpark" }
+			]
+		});
+	});
+
+	it("bills a per-km item by its own distance, not its time span", () => {
+		const payload = toActivityPayload({ ...values, itemDistance: 40 }, "KM");
+
+		expect(payload.startTime).toBeUndefined();
+		expect(payload.endTime).toBeUndefined();
+		expect(payload.itemDistance).toBe(40);
+	});
+
+	it("drops zero-amount transport rows", () => {
+		const payload = toActivityPayload(
+			{
+				...values,
+				transportItems: [
+					{ type: "DISTANCE", amount: 0 },
+					{ type: "PARKING", amount: 0 },
+					{ type: "TOLL", amount: 2 }
+				]
+			},
+			"HOUR"
+		);
+
+		expect(payload.transportItems).toEqual([{ type: "TOLL", amount: 2 }]);
+	});
+
+	it("sends an empty list when the activity's transport is cleared", () => {
+		const payload = toActivityPayload(
+			{ ...values, transportItems: [{ type: "DISTANCE", amount: 0 }] },
+			"HOUR"
+		);
+
+		expect(payload.transportItems).toEqual([]);
+	});
+});

--- a/src/components/activities/activity-form-model.ts
+++ b/src/components/activities/activity-form-model.ts
@@ -1,0 +1,167 @@
+import { stripTimezone, utcDate } from "@/lib/date-utils";
+import { type TransitClient, standaloneTransitFields } from "@/lib/trip-utils";
+import type {
+	ActivitySchema,
+	ActivityTransportItemSchema,
+	ActivityTransportType
+} from "@/schema/activity-schema";
+import { format } from "date-fns";
+
+/**
+ * Hydration and submit transforms for the single-activity form.
+ *
+ * The form is the sole editor for an Activity, and `activity.modify` treats the
+ * submitted payload as authoritative — it recreates the transport items and
+ * writes the transit fields verbatim. So every field the form can save must be
+ * loaded back out of the existing Activity, or saving silently drops it. These
+ * transforms are the round-trip contract, kept out of the component so they can
+ * be tested directly.
+ */
+
+/**
+ * The slice of an existing Activity the form hydrates from. Structural so the
+ * router's `byId` payload (Decimals serialise to strings over the wire) and
+ * hand-built fixtures both satisfy it.
+ */
+export interface ExistingActivityValues {
+	date?: Date;
+	client?: { id: string } | null;
+	supportItem?: { id: string } | null;
+	startTime?: Date | null;
+	endTime?: Date | null;
+	itemDistance?: number | null;
+	transitDistance?: { toString(): string } | null;
+	transitDuration?: { toString(): string } | null;
+	groupSize?: number | null;
+	transportItems?: readonly {
+		type: ActivityTransportType;
+		amount: { toString(): string };
+		note?: string | null;
+	}[];
+}
+
+/**
+ * The Activity Based Transport km field binds to this path, so the distance item
+ * must stay at index 0 of the form's `transportItems`. `hydrateTransportItems`
+ * and `mergeTransportItems` are the only writers of that array and both uphold
+ * it.
+ */
+export const ABT_DISTANCE_FIELD = "transportItems.0.amount" as const;
+
+const numberOrEmpty = (value?: { toString(): string } | null) =>
+	value === null || value === undefined ? "" : String(value);
+
+const emptyDistanceItem = (): ActivityTransportItemSchema => ({
+	type: "DISTANCE",
+	amount: 0
+});
+
+/**
+ * Collapses an Activity's stored transport items into the form's shape: one
+ * DISTANCE row at index 0 carrying the total km driven during the activity,
+ * followed by the parking / toll / other rows. Several stored DISTANCE rows
+ * (a Log Session can capture more than one trip) sum into the single km field
+ * the form exposes, which preserves the billed distance.
+ */
+export function hydrateTransportItems(
+	items?: ExistingActivityValues["transportItems"]
+): ActivityTransportItemSchema[] {
+	const stored = items ?? [];
+
+	const distanceKm = stored
+		.filter((item) => item.type === "DISTANCE")
+		.reduce((total, item) => total + Number(item.amount), 0);
+
+	return [
+		{ type: "DISTANCE", amount: distanceKm },
+		...stored
+			.filter((item) => item.type !== "DISTANCE")
+			.map((item) => ({
+				type: item.type,
+				amount: Number(item.amount),
+				note: item.note ?? undefined
+			}))
+	];
+}
+
+/** The parking / toll / other rows, for the transport items editor. */
+export const otherTransportItems = (
+	items?: ActivityTransportItemSchema[]
+): ActivityTransportItemSchema[] =>
+	(items ?? []).filter((item) => item.type !== "DISTANCE");
+
+/** Puts edited parking / toll / other rows back, keeping the km row at index 0. */
+export const mergeTransportItems = (
+	items: ActivityTransportItemSchema[] | undefined,
+	others: ActivityTransportItemSchema[]
+): ActivityTransportItemSchema[] => [
+	(items ?? []).find((item) => item.type === "DISTANCE") ?? emptyDistanceItem(),
+	...others
+];
+
+/** Form values for a new Activity, or for editing an existing one. */
+export function activityFormDefaults(
+	existing?: ExistingActivityValues
+): ActivitySchema {
+	return {
+		date: existing?.date ?? stripTimezone(new Date()),
+		clientId: existing?.client?.id ?? "",
+		supportItemId: existing?.supportItem?.id ?? "",
+		startTime: existing?.startTime
+			? format(utcDate(existing.startTime), "HH:mm")
+			: "",
+		endTime: existing?.endTime
+			? format(utcDate(existing.endTime), "HH:mm")
+			: "",
+		itemDistance: existing?.itemDistance ?? undefined,
+		transitDistance: numberOrEmpty(existing?.transitDistance),
+		transitDuration: numberOrEmpty(existing?.transitDuration),
+		groupSize: existing?.groupSize ?? undefined,
+		transportItems: hydrateTransportItems(existing?.transportItems)
+	};
+}
+
+/**
+ * The Provider Travel to prefill for an Activity created on its own: the return
+ * trip home → Client → home, which is what `standaloneTransit` writes for an
+ * Activity that ends up alone on its day. The two must agree, or the same
+ * Activity carries different travel depending on which form created it.
+ *
+ * A Client missing a stored distance or travel time leaves that field blank
+ * rather than filling in a 0 the Provider would have to notice and clear.
+ */
+export function standaloneTravelDefaults(
+	client: TransitClient | null
+): Pick<ActivitySchema, "transitDistance" | "transitDuration"> {
+	const travel = standaloneTransitFields(client);
+
+	return {
+		transitDistance:
+			travel.transitDistance == null ? "" : String(travel.transitDistance),
+		transitDuration:
+			travel.transitDuration == null ? "" : String(travel.transitDuration)
+	};
+}
+
+/**
+ * The payload to save. A per-km Support Item is billed by its own distance and
+ * an hourly one by its time span, so only the fields the rate type bills on are
+ * sent. Zero-amount transport rows are dropped — they bill nothing, and an
+ * empty list is how the form clears an Activity's transport.
+ */
+export function toActivityPayload(
+	data: ActivitySchema,
+	rateType?: string
+): ActivitySchema {
+	const isPerKm = rateType === "KM";
+
+	return {
+		...data,
+		startTime: isPerKm ? undefined : data.startTime,
+		endTime: isPerKm ? undefined : data.endTime,
+		itemDistance: isPerKm ? data.itemDistance : undefined,
+		transportItems: (data.transportItems ?? []).filter(
+			(item) => item.amount > 0
+		)
+	};
+}

--- a/src/components/activities/activity-form.tsx
+++ b/src/components/activities/activity-form.tsx
@@ -1,5 +1,6 @@
 import ClientSelect from "@/components/forms/client-select";
 import SupportItemSelect from "@/components/forms/support-item-select";
+import TransportItemsEditor from "@/components/forms/transport-items-editor";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -12,15 +13,24 @@ import {
 	FormMessage
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger
 } from "@/components/ui/popover";
-import { stripTimezone, utcDate } from "@/lib/date-utils";
+import { stripTimezone } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { ActivitySchema, activitySchema } from "@/schema/activity-schema";
+import {
+	ABT_DISTANCE_FIELD,
+	activityFormDefaults,
+	mergeTransportItems,
+	otherTransportItems,
+	standaloneTravelDefaults,
+	toActivityPayload
+} from "@/components/activities/activity-form-model";
 import { ActivityByIdOutput } from "@/server/api/routers/activity-router";
 import { SupportItemListOutput } from "@/server/api/routers/support-item-router";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -33,8 +43,8 @@ import {
 	Unlink
 } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect, useRef, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
 import { useSearchParams } from "next/navigation";
@@ -88,68 +98,59 @@ const ActivityForm = ({ existingActivity }: Props) => {
 	const form = useForm<ActivitySchema>({
 		resolver: zodResolver(activitySchema),
 		mode: "onBlur",
-		defaultValues: {
-			date: existingActivity?.date
-				? existingActivity.date
-				: stripTimezone(new Date()),
-			supportItemId: existingActivity?.supportItem?.id ?? "",
-			clientId: existingActivity?.client?.id ?? "",
-			startTime: existingActivity?.startTime
-				? format(utcDate(existingActivity.startTime), "HH:mm")
-				: "",
-			endTime: existingActivity?.endTime
-				? format(utcDate(existingActivity.endTime), "HH:mm")
-				: "",
-			itemDistance: existingActivity?.itemDistance ?? undefined,
-			transitDistance: existingActivity?.transitDistance
-				? existingActivity?.transitDistance.toString()
-				: "",
-			transitDuration: existingActivity?.transitDuration
-				? existingActivity?.transitDuration.toString()
-				: "",
-			transportItems: [{ type: "DISTANCE", amount: 0 }]
-		}
+		defaultValues: activityFormDefaults(existingActivity)
 	});
 
-	const { data: client, isFetching: isFetchingClient } =
-		trpc.clients.byId.useQuery(
-			{ id: form.watch("clientId") },
-			{ enabled: !!form.watch("clientId") }
-		);
+	const clientId = form.watch("clientId");
+	const supportItemId = form.watch("supportItemId");
 
+	// A per-km Support Item is billed by distance and an hourly one by its time
+	// span, so the rate type decides which fields the form shows and saves.
+	const selectedRateType = supportItems?.find(
+		(i) => i.id === supportItemId
+	)?.rateType;
+
+	const { data: client, isFetching: isFetchingClient } =
+		trpc.clients.byId.useQuery({ id: clientId }, { enabled: !!clientId });
+
+	// The Provider's default Support Item is a starting point for a new Activity
+	// only — never an override of the one an Activity is already billed under.
 	useEffect(() => {
-		if (defaultSupportItemId && supportItems) {
+		if (defaultSupportItemId && !form.getValues("supportItemId")) {
 			form.setValue("supportItemId", defaultSupportItemId);
 		}
-	}, [defaultSupportItemId, form, supportItems]);
+	}, [defaultSupportItemId, form]);
+
+	// Provider Travel auto-fills from the Client's stored distance as the return
+	// trip, once per Client change. Refilling on every render or refetch would
+	// overwrite both an existing Activity's saved travel and any manual override
+	// typed here.
+	const autoFilledClientId = useRef(existingActivity?.client?.id ?? null);
 
 	useEffect(() => {
-		if (!client || isFetchingClient) {
-			form.setValue("transitDistance", "");
-			form.setValue("transitDuration", "");
+		if (!clientId) {
+			if (autoFilledClientId.current !== null) {
+				autoFilledClientId.current = null;
+				form.setValue("transitDistance", "");
+				form.setValue("transitDuration", "");
+			}
 			return;
 		}
 
-		if (client.distanceToClient) {
-			form.setValue("transitDistance", client.distanceToClient.toString());
-		}
+		if (isFetchingClient || client?.id !== clientId) return;
+		if (autoFilledClientId.current === clientId) return;
 
-		if (client.travelTimeToClient) {
-			form.setValue("transitDuration", client.travelTimeToClient.toString());
-		}
-	}, [client, form, isFetchingClient]);
+		autoFilledClientId.current = clientId;
+		const travel = standaloneTravelDefaults(client);
+		form.setValue("transitDistance", travel.transitDistance);
+		form.setValue("transitDuration", travel.transitDuration);
+	}, [client, clientId, form, isFetchingClient]);
 
 	const onSubmit = (data: ActivitySchema) => {
-		const rateType = supportItems?.find(
-			(i) => i.id === data.supportItemId
-		)?.rateType;
-
-		const activityData: ActivitySchema = {
-			...data,
-			startTime: rateType === "KM" ? undefined : data.startTime,
-			endTime: rateType === "KM" ? undefined : data.endTime,
-			itemDistance: rateType === "KM" ? data.itemDistance : undefined
-		};
+		const activityData = toActivityPayload(
+			data,
+			supportItems?.find((i) => i.id === data.supportItemId)?.rateType
+		);
 
 		if (existingActivity?.id) {
 			modifyActivityMutation
@@ -272,8 +273,7 @@ const ActivityForm = ({ existingActivity }: Props) => {
 					/>
 				</div>
 
-				{supportItems?.find((i) => i.id === form.watch("supportItemId"))
-					?.rateType === "KM" ? (
+				{selectedRateType === "KM" ? (
 					<div className="flex w-full gap-4">
 						<FormField
 							name="itemDistance"
@@ -282,10 +282,23 @@ const ActivityForm = ({ existingActivity }: Props) => {
 								<FormItem className="">
 									<FormLabel required>Distance</FormLabel>
 									<FormControl>
-										<Input type="time" {...field} />
+										<Input
+											type="number"
+											step={1}
+											min={0}
+											{...field}
+											value={field.value ?? ""}
+											onChange={(e) =>
+												field.onChange(
+													e.target.value === ""
+														? undefined
+														: parseInt(e.target.value, 10)
+												)
+											}
+										/>
 									</FormControl>
 									<FormDescription>
-										Distance travelled with client
+										Distance travelled with client (in km)
 									</FormDescription>
 									<FormMessage />
 								</FormItem>
@@ -375,7 +388,9 @@ const ActivityForm = ({ existingActivity }: Props) => {
 											{...field}
 										/>
 									</FormControl>
-									<FormDescription>Distance to client (in km)</FormDescription>
+									<FormDescription>
+										Return trip to client (in km)
+									</FormDescription>
 									<FormMessage />
 								</FormItem>
 							)}
@@ -397,7 +412,7 @@ const ActivityForm = ({ existingActivity }: Props) => {
 										/>
 									</FormControl>
 									<FormDescription>
-										Duration of drive (in minutes)
+										Return drive time (in minutes)
 									</FormDescription>
 									<FormMessage />
 								</FormItem>
@@ -406,7 +421,7 @@ const ActivityForm = ({ existingActivity }: Props) => {
 					</div>
 
 					<FormField
-						name="transportItems.0.amount"
+						name={ABT_DISTANCE_FIELD}
 						control={form.control}
 						render={({ field }) => (
 							<FormItem className="w-full grow">
@@ -415,7 +430,10 @@ const ActivityForm = ({ existingActivity }: Props) => {
 									<Input
 										type="number"
 										step={0.1}
+										min={0}
 										{...field}
+										value={field.value ? field.value : ""}
+										placeholder="0"
 										onChange={(e) =>
 											field.onChange(parseFloat(e.target.value) || 0)
 										}
@@ -428,6 +446,22 @@ const ActivityForm = ({ existingActivity }: Props) => {
 							</FormItem>
 						)}
 					/>
+
+					<div className="flex w-full flex-col gap-2">
+						<Label>Parking, Tolls &amp; Other</Label>
+						<Controller
+							control={form.control}
+							name="transportItems"
+							render={({ field }) => (
+								<TransportItemsEditor
+									value={otherTransportItems(field.value)}
+									onChange={(items) =>
+										field.onChange(mergeTransportItems(field.value, items))
+									}
+								/>
+							)}
+						/>
+					</div>
 				</div>
 
 				<div className="mt-4 flex justify-center gap-4">

--- a/src/components/calendar/quick-add-form.tsx
+++ b/src/components/calendar/quick-add-form.tsx
@@ -1,3 +1,4 @@
+import { standaloneTravelDefaults } from "@/components/activities/activity-form-model";
 import ClientSelect from "@/components/forms/client-select";
 import SupportItemSelect from "@/components/forms/support-item-select";
 import { Button } from "@/components/ui/button";
@@ -85,12 +86,14 @@ const QuickAddForm = ({ day, open, onOpenChange, onSuggestTrip }: Props) => {
 			return;
 		}
 
-		if (client.distanceToClient) {
-			form.setValue("transitDistance", client.distanceToClient.toString());
+		// The return trip, matching what a standalone Activity is billed for.
+		const travel = standaloneTravelDefaults(client);
+		if (travel.transitDistance) {
+			form.setValue("transitDistance", travel.transitDistance);
 		}
 
-		if (client.travelTimeToClient) {
-			form.setValue("transitDuration", client.travelTimeToClient.toString());
+		if (travel.transitDuration) {
+			form.setValue("transitDuration", travel.transitDuration);
 		}
 	}, [client, form, isFetchingClient]);
 

--- a/src/lib/trip-utils.test.ts
+++ b/src/lib/trip-utils.test.ts
@@ -2,6 +2,7 @@ import {
 	calculateTripTransit,
 	sortActivitiesByTime,
 	standaloneTransit,
+	standaloneTransitFields,
 	standaloneTransitUpdates,
 	tripTransitUpdates,
 	type InterClientLeg,
@@ -230,6 +231,29 @@ test("standaloneTransit: null client yields zeros", () => {
 		transitDistance: 0,
 		transitDuration: 0,
 		durationCapped: false
+	});
+});
+
+test("standaloneTransitFields: the return trip, capped per leg", () => {
+	expect(
+		standaloneTransitFields({
+			distanceToClient: new Prisma.Decimal(5),
+			travelTimeToClient: new Prisma.Decimal(45)
+		})
+	).toEqual({ transitDistance: 10, transitDuration: 60 });
+});
+
+test("standaloneTransitFields: an unstored value is left unset, not billed as 0", () => {
+	expect(
+		standaloneTransitFields({
+			distanceToClient: null,
+			travelTimeToClient: new Prisma.Decimal(15)
+		})
+	).toEqual({ transitDistance: undefined, transitDuration: 30 });
+
+	expect(standaloneTransitFields(null)).toEqual({
+		transitDistance: undefined,
+		transitDuration: undefined
 	});
 });
 

--- a/src/lib/trip-utils.ts
+++ b/src/lib/trip-utils.ts
@@ -2,6 +2,18 @@ import type { Prisma } from "@/generated/client";
 
 export const MAX_TRANSIT_DURATION_MINUTES = 30;
 
+/**
+ * A stored decimal as it can reach transit calculation: a Prisma Decimal on the
+ * server, or the string it serialises to over the wire.
+ */
+export type DecimalLike = Prisma.Decimal | string | number;
+
+/** The Client fields the home Transit Segments are derived from. */
+export interface TransitClient {
+	distanceToClient?: DecimalLike | null;
+	travelTimeToClient?: DecimalLike | null;
+}
+
 export interface TripActivity {
 	id: string;
 	startTime: Date | null;
@@ -107,12 +119,12 @@ export function calculateTripTransit(
 	return result;
 }
 
-export function standaloneTransit(
-	client: {
-		distanceToClient: Prisma.Decimal | null;
-		travelTimeToClient: Prisma.Decimal | null;
-	} | null
-): TransitValues {
+/**
+ * Provider Travel for an Activity that stands alone on its day: home → Client →
+ * home, so the Client's stored one-way distance and travel time each count
+ * twice, with the Travel Time Cap applied per leg.
+ */
+export function standaloneTransit(client: TransitClient | null): TransitValues {
 	const rawDuration = Number(client?.travelTimeToClient ?? 0);
 	const durationCapped = rawDuration > MAX_TRANSIT_DURATION_MINUTES;
 	const cappedDuration = Math.min(rawDuration, MAX_TRANSIT_DURATION_MINUTES);
@@ -121,6 +133,26 @@ export function standaloneTransit(
 		transitDistance: Number(client?.distanceToClient ?? 0) * 2,
 		transitDuration: cappedDuration * 2,
 		durationCapped
+	};
+}
+
+/**
+ * `standaloneTransit` as the transit fields of an Activity being created, or of
+ * a form prefilling them. A Client with no stored distance or travel time leaves
+ * the matching field unset rather than billing a 0 nobody entered - the single
+ * place that rule lives, so every creation path agrees on it.
+ */
+export function standaloneTransitFields(client: TransitClient | null): {
+	transitDistance?: number;
+	transitDuration?: number;
+} {
+	const transit = standaloneTransit(client);
+
+	return {
+		transitDistance:
+			client?.distanceToClient == null ? undefined : transit.transitDistance,
+		transitDuration:
+			client?.travelTimeToClient == null ? undefined : transit.transitDuration
 	};
 }
 

--- a/src/schema/invoice-schema.ts
+++ b/src/schema/invoice-schema.ts
@@ -20,15 +20,16 @@ export const invoiceSchema = z.object({
 				.array(z.string())
 				.max(MAX_ADDITIONAL_GROUP_PARTICIPANTS)
 				.default([]),
+			// No transit fields: the Provider Travel of an Activity created here is
+			// derived from its Client's stored distance, never submitted - see
+			// `standaloneTransitFields` in the invoice router.
 			activities: z.array(
 				z
 					.object({
 						date: z.date(),
 						startTime: z.string(),
 						endTime: z.string(),
-						itemDistance: z.number(),
-						transitDistance: z.number().optional(),
-						transitDuration: z.number().optional()
+						itemDistance: z.number()
 					})
 					.partial({ startTime: true, endTime: true, itemDistance: true })
 					.refine(

--- a/src/server/api/routers/activity-router.integration.test.ts
+++ b/src/server/api/routers/activity-router.integration.test.ts
@@ -1,5 +1,11 @@
+import {
+	activityFormDefaults,
+	toActivityPayload
+} from "@/components/activities/activity-form-model";
 import { Prisma } from "@/generated/client";
+import { utcDate } from "@/lib/date-utils";
 import prisma from "@/server/prisma";
+import { format } from "date-fns";
 import superjson from "superjson";
 import { beforeEach, expect, test } from "vitest";
 import { callerFor, createTestUser, resetDb } from "../test/harness";
@@ -105,4 +111,100 @@ test("activity.list serializes Decimal fields in the current on-the-wire shape",
 	expect(wire.json.transitDistance).toBe("12.5");
 	expect(wire.meta?.values ?? {}).not.toHaveProperty("transitDistance");
 	expect(wire.meta?.values).toHaveProperty("date");
+});
+
+// The edit form's round trip: byId -> form defaults -> submit payload -> modify.
+// Exercised end to end because the loss the form used to cause was invisible at
+// either end on its own - the payload looked valid, it just omitted fields.
+test("editing an activity through the form's transforms keeps its transport and travel", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const supportItem = await createSupportItem(user.id);
+
+	const created = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0,
+			transitDistance: "12.5",
+			transitDuration: "20",
+			transportItems: [
+				{ type: "DISTANCE", amount: 8.4 },
+				{ type: "PARKING", amount: 6.5, note: "carpark" }
+			]
+		}
+	});
+
+	const existing = await caller.activity.byId({ id: created.id });
+	const defaults = activityFormDefaults(existing);
+
+	// The worker only edits the end time; everything else must survive untouched.
+	await caller.activity.modify({
+		id: created.id,
+		activity: toActivityPayload({ ...defaults, endTime: "11:00" }, "HOUR")
+	});
+
+	const saved = await caller.activity.byId({ id: created.id });
+
+	expect(format(utcDate(saved.endTime!), "HH:mm")).toBe("11:00");
+	expect(saved.supportItem.id).toBe(supportItem.id);
+	expect(saved.transitDistance?.toString()).toBe("12.5");
+	expect(saved.transitDuration?.toString()).toBe("20");
+	expect(
+		saved.transportItems
+			.map((item) => ({ type: item.type, amount: Number(item.amount) }))
+			.sort((a, b) => a.type.localeCompare(b.type))
+	).toEqual([
+		{ type: "DISTANCE", amount: 8.4 },
+		{ type: "PARKING", amount: 6.5 }
+	]);
+});
+
+test("clearing an activity's provider travel and transport removes them", async () => {
+	const user = await createTestUser();
+	const caller = callerFor(user);
+
+	const client = await caller.clients.create({ client: { name: "Jane" } });
+	const supportItem = await createSupportItem(user.id);
+
+	const created = await caller.activity.add({
+		activity: {
+			clientId: client.id,
+			supportItemId: supportItem.id,
+			date: new Date("2024-01-01"),
+			startTime: "09:00",
+			endTime: "10:00",
+			itemDistance: 0,
+			transitDistance: "12.5",
+			transportItems: [{ type: "DISTANCE", amount: 8.4 }]
+		}
+	});
+
+	const defaults = activityFormDefaults(
+		await caller.activity.byId({ id: created.id })
+	);
+
+	await caller.activity.modify({
+		id: created.id,
+		activity: toActivityPayload(
+			{
+				...defaults,
+				transitDistance: "",
+				transitDuration: "",
+				transportItems: [{ type: "DISTANCE", amount: 0 }]
+			},
+			"HOUR"
+		)
+	});
+
+	const saved = await caller.activity.byId({ id: created.id });
+
+	expect(saved.transitDistance).toBeNull();
+	expect(saved.transitDuration).toBeNull();
+	expect(saved.transportItems).toEqual([]);
 });

--- a/src/server/api/routers/activity-router.ts
+++ b/src/server/api/routers/activity-router.ts
@@ -429,8 +429,10 @@ export const activityRouter = router({
 					...activityData,
 					startTime,
 					endTime,
-					transitDistance: activityData.transitDistance || undefined,
-					transitDuration: activityData.transitDuration || undefined,
+					// Blanked out means the Activity has no Provider Travel, so clear it
+					// rather than leaving the previous value in place.
+					transitDistance: activityData.transitDistance || null,
+					transitDuration: activityData.transitDuration || null,
 					transportItems:
 						transportItems && transportItems.length > 0
 							? {
@@ -544,6 +546,19 @@ export const activityRouter = router({
 
 			const { activities, tripId } = await ctx.prisma.$transaction((tx) =>
 				createActivityBatch(tx, ctx.session.user.id, sorted, (created) => {
+					// A lone Activity forms no Trip but still drives home → Client →
+					// home, so it bills the standalone return trip - the same travel it
+					// would get from Promotion or from being dropped out of a Trip.
+					// Transit entered by hand stays untouched.
+					if (created.length === 1) {
+						const [only] = created;
+						const handEntered =
+							Number(only.transitDistance ?? 0) > 0 ||
+							Number(only.transitDuration ?? 0) > 0;
+
+						return handEntered ? null : { activities: created, legs: [] };
+					}
+
 					// A manually entered day only becomes a Trip when its Activities
 					// run back to back (end time equals the next start time); anything
 					// else keeps the transit that was entered by hand.

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -5,6 +5,7 @@ import {
 import { buildInvoiceVersionContent } from "@/lib/invoice-version";
 import { loadInvoiceForPdf } from "@/lib/pdf-generation";
 import { baseListQueryInput } from "@/lib/trpc";
+import { standaloneTransitFields } from "@/lib/trip-utils";
 import { activitySchema } from "@/schema/activity-schema";
 import {
 	InvoiceSchema,
@@ -122,8 +123,10 @@ const generateNestedWriteForActivities = (
 				startTime: parseUtcTime(activity.startTime),
 				endTime: parseUtcTime(activity.endTime),
 				clientId: client.id,
-				transitDistance: client.distanceToClient ?? undefined,
-				transitDuration: client.travelTimeToClient ?? undefined,
+				// Each Activity created here stands alone - the invoice form builds no
+				// Trips - so its Provider Travel is the return trip home → Client →
+				// home, capped per leg.
+				...standaloneTransitFields(client),
 				supportItemId,
 				groupSize,
 				ownerId
@@ -151,8 +154,10 @@ const generateNestedWriteForGroupActivities = (
 					startTime: parseUtcTime(activity.startTime),
 					endTime: parseUtcTime(activity.endTime),
 					clientId: groupClientId,
-					transitDistance: client?.distanceToClient ?? undefined,
-					transitDuration: client?.travelTimeToClient ?? undefined,
+					// As above: the mirrored Activity bills its own participant's return
+					// trip. (Unlike a promoted group Session, where the day's travel
+					// bills once - see `createActivityBatch`.)
+					...standaloneTransitFields(client ?? null),
 					groupSize,
 					ownerId
 				}));

--- a/src/server/api/test/standalone-provider-travel.integration.test.ts
+++ b/src/server/api/test/standalone-provider-travel.integration.test.ts
@@ -1,0 +1,248 @@
+import prisma from "@/server/prisma";
+import type { User } from "@/generated/client";
+import { beforeEach, describe, expect, test } from "vitest";
+import { callerFor, createTestUser, resetDb } from "./harness";
+
+/**
+ * One invariant, checked on every path that can create an Activity: an Activity
+ * that stands alone on its day bills the return trip home → Client → home, with
+ * the Travel Time Cap applied to each leg. Trip allocation is the deliberate
+ * exception - a Trip's legs share the day's driving, so only its last leg
+ * carries a drive home - and `trip-lifecycle.integration.test.ts` pins that
+ * down. These tests exist because the two rules were each re-derived per path
+ * and drifted: several paths billed a single leg, or none at all.
+ *
+ * The paths covered elsewhere: `log.promoteDay` in
+ * `log-promotion.integration.test.ts`, dropping an Activity out of a Trip in
+ * `trip-lifecycle.integration.test.ts`, and `activity.add` in
+ * `activity-router.integration.test.ts` - it stores the travel the single-
+ * activity form submits verbatim, and the form derives it with
+ * `standaloneTravelDefaults` (unit-tested in `activity-form-model.test.ts`).
+ */
+
+beforeEach(async () => {
+	await resetDb();
+});
+
+// 55 minutes each way, so each leg caps to 30: the return trip is 80 km / 60 min
+// and a path that bills one leg shows up as 40 km / 55 min.
+const STORED_TRAVEL = { distanceToClient: 40, travelTimeToClient: 55 };
+const RETURN_TRIP = { transitDistance: 80, transitDuration: 60 };
+
+async function createSupportItem(owner: User, isGroup = false) {
+	return prisma.supportItem.create({
+		data: {
+			description: isGroup ? "Group Support" : "Support",
+			isGroup,
+			weekdayCode: isGroup ? "04_102_0136_6_1" : "01_011_0107_1_1",
+			weekdayRate: 100,
+			ownerId: owner.id
+		}
+	});
+}
+
+async function createClient(owner: User, name: string, travel = STORED_TRAVEL) {
+	return prisma.client.create({
+		data: { name, ownerId: owner.id, ...travel }
+	});
+}
+
+const travelOf = (activity: {
+	transitDistance: unknown;
+	transitDuration: unknown;
+}) => ({
+	transitDistance: Number(activity.transitDistance),
+	transitDuration: Number(activity.transitDuration)
+});
+
+describe("activity.bulkAdd", () => {
+	test("a lone Activity bills the return trip, not one leg", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner, "Client 1");
+
+		const { activities, tripId } = await caller.activity.bulkAdd({
+			activities: [
+				{
+					clientId: client.id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-01-01"),
+					startTime: "09:00",
+					endTime: "10:00"
+				}
+			]
+		});
+
+		expect(tripId).toBeNull();
+		expect(travelOf(activities[0])).toEqual(RETURN_TRIP);
+	});
+
+	test("transit entered by hand on a lone Activity is not overwritten", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner, "Client 1");
+
+		const { activities } = await caller.activity.bulkAdd({
+			activities: [
+				{
+					clientId: client.id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-01-01"),
+					startTime: "09:00",
+					endTime: "10:00",
+					transitDistance: "42",
+					transitDuration: "17"
+				}
+			]
+		});
+
+		expect(travelOf(activities[0])).toEqual({
+			transitDistance: 42,
+			transitDuration: 17
+		});
+	});
+
+	test("a Client with no stored travel bills no provider travel", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await prisma.client.create({
+			data: { name: "No travel", ownerId: owner.id }
+		});
+
+		const { activities } = await caller.activity.bulkAdd({
+			activities: [
+				{
+					clientId: client.id,
+					supportItemId: supportItem.id,
+					date: new Date("2024-01-01"),
+					startTime: "09:00",
+					endTime: "10:00"
+				}
+			]
+		});
+
+		const saved = await prisma.activity.findUniqueOrThrow({
+			where: { id: activities[0].id }
+		});
+		expect(Number(saved.transitDistance)).toBe(0);
+		expect(Number(saved.transitDuration)).toBe(0);
+	});
+});
+
+describe("invoice.create", () => {
+	test("an Activity created on the invoice bills the return trip", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await createClient(owner, "Client 1");
+
+		const invoice = await caller.invoice.create({
+			invoice: {
+				clientId: client.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					{
+						supportItemId: supportItem.id,
+						groupClientIds: [],
+						activities: [
+							{
+								date: new Date("2024-01-01"),
+								startTime: "09:00",
+								endTime: "11:00"
+							}
+						]
+					}
+				]
+			}
+		});
+
+		const activities = await prisma.activity.findMany({
+			where: { invoiceId: invoice.id }
+		});
+
+		expect(activities).toHaveLength(1);
+		expect(travelOf(activities[0])).toEqual(RETURN_TRIP);
+	});
+
+	test("each mirrored group participant bills its own return trip", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner, true);
+		const primary = await createClient(owner, "Primary");
+		const other = await createClient(owner, "Other", {
+			distanceToClient: 6,
+			travelTimeToClient: 12
+		});
+
+		await caller.invoice.create({
+			invoice: {
+				clientId: primary.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					{
+						supportItemId: supportItem.id,
+						groupClientIds: [other.id],
+						activities: [
+							{
+								date: new Date("2024-01-01"),
+								startTime: "09:00",
+								endTime: "11:00"
+							}
+						]
+					}
+				]
+			}
+		});
+
+		const byClient = new Map(
+			(await prisma.activity.findMany({ where: { ownerId: owner.id } })).map(
+				(activity) => [activity.clientId, travelOf(activity)]
+			)
+		);
+
+		expect(byClient.get(primary.id)).toEqual(RETURN_TRIP);
+		expect(byClient.get(other.id)).toEqual({
+			transitDistance: 12,
+			transitDuration: 24
+		});
+	});
+
+	test("a Client with no stored travel leaves the created Activity's travel unset", async () => {
+		const owner = await createTestUser();
+		const caller = callerFor(owner);
+		const supportItem = await createSupportItem(owner);
+		const client = await prisma.client.create({
+			data: { name: "No travel", ownerId: owner.id }
+		});
+
+		const invoice = await caller.invoice.create({
+			invoice: {
+				clientId: client.id,
+				invoiceNo: "INV-1",
+				activitiesToCreate: [
+					{
+						supportItemId: supportItem.id,
+						groupClientIds: [],
+						activities: [
+							{
+								date: new Date("2024-01-01"),
+								startTime: "09:00",
+								endTime: "11:00"
+							}
+						]
+					}
+				]
+			}
+		});
+
+		const [activity] = await prisma.activity.findMany({
+			where: { invoiceId: invoice.id }
+		});
+
+		expect(activity.transitDistance).toBeNull();
+		expect(activity.transitDuration).toBeNull();
+	});
+});


### PR DESCRIPTION
Two related defects in how an Activity's Provider Travel and other billing fields are handled outside of a Trip. Both were found by hand-testing the single-Activity form, and each turned out to be one instance of a rule that had been re-derived per code path and drifted.

## 1. The edit form overwrote what it had just loaded

Opening an existing Activity's edit form ran two effects that fought the loaded values: the Provider's default Support Item was written over the Support Item the Activity is actually billed under, and the Client's stored distance was written over the Activity's saved travel on every render and refetch. The form also never loaded `groupSize` or the Activity Based Transport rows at all, and `activity.modify` treats the submitted payload as authoritative, so a save silently dropped them.

- The default Support Item now only fills an empty field, so it is a starting point for a new Activity rather than an override.
- Travel auto-fills once per Client change, tracked by a ref, so a refetch or a manual override is never clobbered.
- Blanking the travel fields now saves as `null` instead of leaving the previous value in place - "no Provider Travel" is a thing the form can express.
- The hydration and submit transforms moved out of the component into `activity-form-model.ts`, which is where the round-trip contract now lives: every field the form can save is loaded back out of the Activity. Several stored DISTANCE rows (a Log Session can capture more than one trip) sum into the single km field the form exposes, which preserves the billed distance.

## 2. Provider Travel was wrong on every path that creates a single Activity

`CONTEXT.md` defines Provider Travel as home -> Client -> home, and `standaloneTransit` implements exactly that: the Client's stored one-way values doubled, with the Travel Time Cap applied per leg. Promotion and the Trip lifecycle used it. Every other creation path had its own version:

| Path | Before | Now |
| --- | --- | --- |
| Single-Activity form (`activity.add`) | one-way, uncapped | return trip, capped |
| Calendar quick-add (`activity.add`) | one-way, uncapped | return trip, capped |
| Multi-Activity form, one row (`activity.bulkAdd`) | **no Provider Travel at all** | return trip, capped |
| Invoice create form (`invoice.create`) | one-way, uncapped | return trip, capped |
| Invoice create form, group mirrors | one-way, uncapped | return trip, capped |
| Log Promotion (`log.promoteDay`) | correct | unchanged |
| Trip create / remove / dissolve | correct | unchanged |

The `bulkAdd` row is the dashboard's "Add Activity" button, the most-used creation flow. `createActivityBatch`'s `planTravel` callback returned `null` for a day of fewer than two Activities on the grounds that such a day "keeps the transit that was entered by hand" - but the multi-Activity form sends no transit, so a lone Activity was saved with none. Its e2e test only asserted the success toast, so nothing caught it.

New `standaloneTransitFields` in `trip-utils.ts` is now the single home for the rule, including the "leave it unset rather than bill a 0 nobody entered" case, and the forms, the invoice router and `bulkAdd` all read it. `bulkAdd` still defers to transit entered by hand, so the existing non-contiguous-day behaviour is untouched.

Trip logic is deliberately unchanged: `calculateTripTransit`, the contiguity check and the two-or-more Trip assembly rule are exactly as they were, and the trip allocation tests pass unmodified. A Trip's legs share the day's driving, so only its last leg carries a drive home - that is the intended exception to the return-trip rule, and it stays pinned by `trip-lifecycle.integration.test.ts`.

## 3. Dead inputs on the invoice schema

`invoiceSchema.activitiesToCreate[].activities[]` accepted `transitDistance` and `transitDuration`, but the router spread them and then overwrote both from the Client, and no UI ever set them. Removed, with a comment recording where the value actually comes from.

## Tests

- `standalone-provider-travel.integration.test.ts` (new, 6 tests) states the invariant once and checks it per creation path: `bulkAdd` for a lone Activity, for hand-entered transit, and for a Client with nothing stored; `invoice.create` for the primary Activity, for group mirrors, and for a Client with nothing stored. Its docstring points at where the remaining paths are covered.
- `activity-form-model.test.ts` (new, 14 tests) covers the round-trip contract directly: every saved field loading back, a zero transit distance surviving, the DISTANCE row staying at index 0, per-km vs hourly payloads, and the return-trip prefill with its cap and blank cases.
- `activity-router.integration.test.ts` gains coverage for `modify` preserving transit / transport / groupSize, and for blanked travel clearing to `null`.
- `trip-utils.test.ts` gains two tests for `standaloneTransitFields`.
- e2e: a new test that a fresh Activity prefills the Client's return trip (40 km / 55 min stored -> 80 km / 60 min shown), a new test that editing an Activity keeps its Support Item, travel and transport, and "Can create activity" now asserts the saved travel instead of just the toast. `createRandomActivity` takes optional billing fields so a fixture can carry transit and transport rows.

## Verification

Type-check clean, Prettier clean, lint 0 errors (5 pre-existing React Compiler warnings about `form.watch`, in files this PR does not change in that respect). 227 unit, 143 integration, 28 e2e - all passing. No schema change, so no migration.

## Noted for later, not in this PR

- `bulkAdd` with two or more non-contiguous rows, or with any group row (`autoCreateTrip: false`), still saves zero Provider Travel for every Activity. Same class of bug, but the right answer is a policy call: two separate outings in a day are arguably two return trips, and a group day should bill travel once, as Promotion does.
- Invoice-created group mirrors each bill their own return trip, whereas a promoted group Session bills the day's travel once with the mirrors left null. Two policies for one situation.
- `calculateTripTransit` gives a one-Activity Trip one-way travel (noted against #429). Not reachable today, since a Trip needs two legs.
