### PR TITLE
chore: migrate Zod 3 to 4 (#447)

### DIFF
--- a/e2e/support-items.test.ts
+++ b/e2e/support-items.test.ts
@@ -57,3 +57,27 @@ test("Can create, update, and delete support items", async ({ page }) => {
 
 	await waitForAlert(page, "Support Item Deleted");
 });
+
+test("Support item form shows its own validation messages", async ({
+	page
+}) => {
+	await page.goto("/dashboard/support-items/create");
+
+	const weekdayCode = page.getByPlaceholder("XX_XXX_XXXX_X_X").first();
+	const weekdayRate = page.getByPlaceholder("rate").first();
+
+	// An untouched weekday rate never reaches the coercion.
+	await page.getByRole("button", { name: "Create" }).click();
+	await expect(page.getByText("Must be a number")).toBeVisible();
+
+	await weekdayCode.fill("nope");
+	await weekdayRate.fill("1.234");
+	await page.getByRole("button", { name: "Create" }).click();
+
+	await expect(
+		page.getByText("Must be in format XX_XXX_XXXX_X_X")
+	).toBeVisible();
+	await expect(
+		page.getByText("Can't be more than 2 decimal places (x.xx)")
+	).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@base-ui/react": "1.6.0",
 		"@date-fns/tz": "1.5.0",
 		"@headlessui/react": "2.2.10",
-		"@hookform/resolvers": "4.1.3",
+		"@hookform/resolvers": "5.5.7",
 		"@prisma/adapter-pg": "7.8.0",
 		"@prisma/client": "7.8.0",
 		"@radix-ui/react-alert-dialog": "1.1.15",
@@ -81,7 +81,7 @@
 		"react-pdf": "10.4.1",
 		"react-toastify": "11.1.0",
 		"superjson": "2.2.6",
-		"zod": "3.24.2"
+		"zod": "4.4.3"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@hookform/resolvers':
-        specifier: 4.1.3
-        version: 4.1.3(react-hook-form@7.80.0(react@19.2.7))
+        specifier: 5.5.7
+        version: 5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(effect@3.20.0)(react-hook-form@7.80.0(react@19.2.7))(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       '@prisma/adapter-pg':
         specifier: 7.8.0
         version: 7.8.0
@@ -141,8 +141,8 @@ importers:
         specifier: 2.2.6
         version: 2.2.6
       zod:
-        specifier: 3.24.2
-        version: 3.24.2
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@commitlint/cli':
         specifier: 21.0.2
@@ -999,10 +999,83 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hookform/resolvers@4.1.3':
-    resolution: {integrity: sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==}
+  '@hookform/resolvers@5.5.7':
+    resolution: {integrity: sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      '@sinclair/typebox': '>=0.25.24'
+      '@standard-schema/spec': ^1.0.0
+      '@typeschema/main': '>=0.13.7'
+      '@vinejs/vine': ^2.0.0 || ^3.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^0.7.0
+      class-transformer: '>=0.4.0'
+      class-validator: '>=0.12.0'
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0
+      nope-validator: '>=0.12.0'
+      react-hook-form: ^7.55.0
+      superstruct: '>=0.12.0'
+      typanion: ^3.3.2
+      valibot: '>=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc'
+      vest: '>=3.0.0'
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@standard-schema/spec':
+        optional: true
+      '@typeschema/main':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5884,11 +5957,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -6516,10 +6586,16 @@ snapshots:
     dependencies:
       hono: 4.12.26
 
-  '@hookform/resolvers@4.1.3(react-hook-form@7.80.0(react@19.2.7))':
+  '@hookform/resolvers@5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(effect@3.20.0)(react-hook-form@7.80.0(react@19.2.7))(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.80.0(react@19.2.7)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      effect: 3.20.0
+      valibot: 1.2.0(typescript@5.9.3)
+      zod: 4.4.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -9446,8 +9522,8 @@ snapshots:
       '@babel/parser': 7.29.0
       eslint: 9.39.2(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11586,10 +11662,8 @@ snapshots:
       grammex: 3.1.12
       graphmatch: 1.1.1
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@3.24.2: {}
-
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/src/components/account/account-form.tsx
+++ b/src/components/account/account-form.tsx
@@ -11,7 +11,7 @@ import {
 import Heading from "@/components/ui/heading";
 import { Input } from "@/components/ui/input";
 import { trpc } from "@/lib/trpc";
-import { UserSchema, userSchema } from "@/schema/user-schema";
+import { UserFormValues, UserSchema, userSchema } from "@/schema/user-schema";
 import { UserFetchOutput } from "@/server/api/routers/user-router";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo } from "react";
@@ -41,7 +41,7 @@ const AccountForm = ({ existingUser }: Props) => {
 		[existingUser]
 	);
 
-	const form = useForm<UserSchema>({
+	const form = useForm<UserFormValues, unknown, UserSchema>({
 		mode: "onBlur",
 		resolver: zodResolver(userSchema),
 		defaultValues: existingUserWithDefaults

--- a/src/components/activities/multi-activity-form-model.ts
+++ b/src/components/activities/multi-activity-form-model.ts
@@ -36,7 +36,7 @@ export const activityRowSchema = z
 
 		if (!row.clientId) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: "custom",
 				message: "Client is required",
 				path: ["clientId"]
 			});
@@ -44,7 +44,7 @@ export const activityRowSchema = z
 
 		if (row.isGroup && row.groupClientIds.length === 0) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: "custom",
 				message: "At least one other participant is required",
 				path: ["groupClientIds"]
 			});
@@ -52,7 +52,7 @@ export const activityRowSchema = z
 
 		if (!row.timeRange.startTime || !row.timeRange.endTime) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: "custom",
 				message: "Time range is required",
 				path: ["timeRange"]
 			});
@@ -73,7 +73,7 @@ export const activityRowSchema = z
 				);
 				if (timeIssue) {
 					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
+						code: "custom",
 						message: timeIssue.message,
 						path: ["timeRange"]
 					});

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -13,7 +13,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 const loginFormSchema = z.object({
-	email: z.string().email()
+	email: z.email()
 });
 type LoginFormSchema = z.infer<typeof loginFormSchema>;
 

--- a/src/components/clients/support-item-override-dialog.tsx
+++ b/src/components/clients/support-item-override-dialog.tsx
@@ -21,6 +21,7 @@ import { Separator } from "@/components/ui/separator";
 import { trpc } from "@/lib/trpc";
 import { decimalToCurrencyString } from "@/lib/utils";
 import {
+	SupportItemRatesFormValues,
 	SupportItemRatesSchema,
 	supportItemRatesSchema
 } from "@/schema/support-item-rates-schema";
@@ -37,7 +38,11 @@ interface Props {
 const SupportItemOverrideDialog = ({ clientId }: Props) => {
 	const [open, setOpen] = useState(false);
 
-	const form = useForm<SupportItemRatesSchema>({
+	const form = useForm<
+		SupportItemRatesFormValues,
+		unknown,
+		SupportItemRatesSchema
+	>({
 		resolver: zodResolver(supportItemRatesSchema),
 		defaultValues: {
 			supportItemId: ""

--- a/src/components/invoices/invoice-activity-creation-form.tsx
+++ b/src/components/invoices/invoice-activity-creation-form.tsx
@@ -19,7 +19,7 @@ import {
 import { stripTimezone } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import { InvoiceSchema } from "@/schema/invoice-schema";
+import { InvoiceFormValues } from "@/schema/invoice-schema";
 import { format } from "date-fns";
 import {
 	ArrowRight,
@@ -40,10 +40,10 @@ import {
 } from "react-hook-form";
 
 interface Props {
-	control: Control<InvoiceSchema>;
-	getValues: UseFormGetValues<InvoiceSchema>;
-	setValue: UseFormSetValue<InvoiceSchema>;
-	watch: UseFormWatch<InvoiceSchema>;
+	control: Control<InvoiceFormValues>;
+	getValues: UseFormGetValues<InvoiceFormValues>;
+	setValue: UseFormSetValue<InvoiceFormValues>;
+	watch: UseFormWatch<InvoiceFormValues>;
 }
 
 const InvoiceActivityCreationForm = ({

--- a/src/components/invoices/invoice-form.tsx
+++ b/src/components/invoices/invoice-form.tsx
@@ -20,7 +20,11 @@ import {
 import { stripTimezone, utcDate } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import { InvoiceSchema, invoiceSchema } from "@/schema/invoice-schema";
+import {
+	InvoiceFormValues,
+	InvoiceSchema,
+	invoiceSchema
+} from "@/schema/invoice-schema";
 import { InvoiceByIdOutput } from "@/server/api/routers/invoice-router";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
@@ -39,7 +43,7 @@ interface Props {
 const InvoiceForm = ({ existingInvoice, onSubmit }: Props) => {
 	const router = useRouter();
 
-	const form = useForm<InvoiceSchema>({
+	const form = useForm<InvoiceFormValues, unknown, InvoiceSchema>({
 		resolver: zodResolver(invoiceSchema),
 		defaultValues: {
 			...existingInvoice,

--- a/src/components/invoices/unnassigned-activities.tsx
+++ b/src/components/invoices/unnassigned-activities.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import Heading from "@/components/ui/heading";
 import { cn } from "@/lib/utils";
-import { InvoiceSchema } from "@/schema/invoice-schema";
+import { InvoiceFormValues } from "@/schema/invoice-schema";
 import { ActivityListOutput } from "@/server/api/routers/activity-router";
 import { utcDate } from "@/lib/date-utils";
 import { format } from "date-fns";
@@ -10,8 +10,8 @@ import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
 
 interface Props {
 	activities: ActivityListOutput["activities"];
-	getValues: UseFormGetValues<InvoiceSchema>;
-	setValue: UseFormSetValue<InvoiceSchema>;
+	getValues: UseFormGetValues<InvoiceFormValues>;
+	setValue: UseFormSetValue<InvoiceFormValues>;
 }
 
 const UnassignedActivities = ({ activities, getValues, setValue }: Props) => {

--- a/src/components/support-items/support-item-form.tsx
+++ b/src/components/support-items/support-item-form.tsx
@@ -19,7 +19,10 @@ import {
 	SelectValue
 } from "@/components/ui/select";
 import { trpc } from "@/lib/trpc";
-import type { SupportItemSchema } from "@/schema/support-item-schema";
+import type {
+	SupportItemFormValues,
+	SupportItemSchema
+} from "@/schema/support-item-schema";
 import { supportItemSchema } from "@/schema/support-item-schema";
 import { SupportItemByIdOutput } from "@/server/api/routers/support-item-router";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -41,7 +44,7 @@ const SupportItemForm = ({ existingSupportItem }: Props) => {
 	const createSupportItemMutation = trpc.supportItem.create.useMutation();
 	const updateSupportItemMutation = trpc.supportItem.update.useMutation();
 
-	const form = useForm<SupportItemSchema>({
+	const form = useForm<SupportItemFormValues, unknown, SupportItemSchema>({
 		resolver: zodResolver(supportItemSchema),
 		defaultValues: {
 			description: existingSupportItem?.description ?? "",

--- a/src/env/schema.js
+++ b/src/env/schema.js
@@ -4,12 +4,12 @@ const { z } = require("zod");
 const serverSchema = z.object({
 	NODE_ENV: z.enum(["development", "test", "production"]),
 	NEXTAUTH_SECRET: z.string().min(1),
-	NEXTAUTH_URL: z.string().url().optional(),
+	NEXTAUTH_URL: z.url().optional(),
 	GOOGLE_ID: z.string().optional(),
 	GOOGLE_SECRET: z.string().optional(),
 	EMAIL_SERVER: z.string().optional(),
 	EMAIL_FROM: z.string().optional(),
-	SEED_EMAIL: z.string().email().optional()
+	SEED_EMAIL: z.email().optional()
 });
 
 module.exports = { serverSchema };

--- a/src/schema/activity-schema.test.ts
+++ b/src/schema/activity-schema.test.ts
@@ -44,3 +44,17 @@ test("accepts the distance-only shape with no times", () => {
 
 	expect(result.success).toBe(true);
 });
+
+test("reports a missing date with its own message", () => {
+	const result = activitySchema.safeParse({
+		supportItemId: base.supportItemId,
+		clientId: base.clientId,
+		startTime: "09:00",
+		endTime: "17:00"
+	});
+
+	expect(result.success).toBe(false);
+	if (!result.success) {
+		expect(result.error.issues[0]?.message).toBe("Date is required");
+	}
+});

--- a/src/schema/activity-schema.ts
+++ b/src/schema/activity-schema.ts
@@ -1,3 +1,4 @@
+import { requiredDate } from "@/schema/fields";
 import { z } from "zod";
 
 export const activityTransportTypeEnum = z.enum([
@@ -23,7 +24,7 @@ export const activitySchema = z
 		id: z.string().optional(),
 		supportItemId: z.string(),
 		clientId: z.string().min(1, "Client is required"),
-		date: z.date({ required_error: "Date is required" }),
+		date: requiredDate("Date is required"),
 		startTime: z.string().min(1, "Start time is required"),
 		endTime: z.string().min(1, "End time is required"),
 		itemDistance: z.number(),

--- a/src/schema/fields.ts
+++ b/src/schema/fields.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const NOT_A_NUMBER_MESSAGE = "Must be a number";
+export const TOO_MANY_DECIMALS_MESSAGE =
+	"Can't be more than 2 decimal places (x.xx)";
+
+/**
+ * A number field fed by a DOM number input, which hands back a string - so it
+ * coerces.
+ *
+ * The `<string | number>` type argument is load-bearing: a bare
+ * `z.coerce.number()` infers `unknown` as its *input* type, and `zodResolver`
+ * types a form's field values from the input type - so without it every numeric
+ * form field would be typed `unknown`.
+ */
+export const numberFromInput = (error = NOT_A_NUMBER_MESSAGE) =>
+	z.coerce.number<string | number>({ error });
+
+/**
+ * An optional rate in dollars - a Support Item's own Day Rate, or a Client's
+ * Custom Rate override of one.
+ *
+ * Only an *absent* field is left unset: a blank input arrives as `""`, which
+ * coerces to `0`.
+ */
+export const optionalRate = numberFromInput()
+	.multipleOf(0.01, TOO_MANY_DECIMALS_MESSAGE)
+	.optional();
+
+/**
+ * A required date, chosen from a date picker. Only a missing date gets the
+ * custom message; a wrong type falls through to Zod's own wording.
+ */
+export const requiredDate = (message: string) =>
+	z.date({
+		error: (issue) => (issue.input === undefined ? message : undefined)
+	});

--- a/src/schema/invoice-schema.ts
+++ b/src/schema/invoice-schema.ts
@@ -41,3 +41,8 @@ export const invoiceSchema = z.object({
 	)
 });
 export type InvoiceSchema = z.infer<typeof invoiceSchema>;
+/**
+ * The form's field values: `groupClientIds` is filled in by its default, so the
+ * input shape differs from the parsed output.
+ */
+export type InvoiceFormValues = z.input<typeof invoiceSchema>;

--- a/src/schema/log-schema.ts
+++ b/src/schema/log-schema.ts
@@ -1,3 +1,4 @@
+import { requiredDate } from "@/schema/fields";
 import { z } from "zod";
 
 export const timeOfDaySchema = z
@@ -25,7 +26,7 @@ export const workSessionTransportItemSchema = z.object({
 // replays them.
 export const workSessionStartSchema = z.object({
 	id: z.string().optional(),
-	date: z.date({ required_error: "Date is required" }),
+	date: requiredDate("Date is required"),
 	startTime: timeOfDaySchema,
 	// The client's tap-time stamp: offline captures are stamped when made, not
 	// when they sync, and last-write-wins compares these stamps.

--- a/src/schema/support-item-rates-schema.test.ts
+++ b/src/schema/support-item-rates-schema.test.ts
@@ -1,0 +1,61 @@
+import { supportItemRatesSchema } from "@/schema/support-item-rates-schema";
+
+import { expect, test } from "vitest";
+
+/**
+ * Custom Rate overrides are typed into number inputs, so they arrive as
+ * strings. These assertions pin the message each path shows the Provider,
+ * matching the wording of the Support Item form's own rate fields.
+ */
+const messageFor = (input: unknown, field: string) => {
+	const result = supportItemRatesSchema.safeParse(input);
+	if (result.success) return undefined;
+	return result.error.issues.find((issue) => issue.path.join(".") === field)
+		?.message;
+};
+
+test("coerces overrides typed as strings and leaves absent ones unset", () => {
+	const result = supportItemRatesSchema.safeParse({
+		supportItemId: "support-item-1",
+		weekdayRate: "67.56"
+	});
+
+	expect(result.success).toBe(true);
+	expect(result.data?.weekdayRate).toBe(67.56);
+	expect(result.data?.sundayRate).toBeUndefined();
+});
+
+// Current behaviour, not desired behaviour: the dialog submits every rate
+// field, so a blank one arrives as "" and coerces to a $0 override that then
+// wins over the Support Item's own rate. Fixing that is its own change.
+test("coerces a blank override to zero", () => {
+	const result = supportItemRatesSchema.safeParse({
+		supportItemId: "support-item-1",
+		weekdayRate: ""
+	});
+
+	expect(result.success).toBe(true);
+	expect(result.data?.weekdayRate).toBe(0);
+});
+
+test("rejects a non-numeric override", () => {
+	expect(
+		messageFor(
+			{ supportItemId: "support-item-1", weekdayRate: "abc" },
+			"weekdayRate"
+		)
+	).toBe("Must be a number");
+});
+
+test("rejects more than two decimal places", () => {
+	expect(
+		messageFor(
+			{ supportItemId: "support-item-1", sundayRate: "1.234" },
+			"sundayRate"
+		)
+	).toBe("Can't be more than 2 decimal places (x.xx)");
+});
+
+test("requires a support item", () => {
+	expect(messageFor({ supportItemId: "" }, "supportItemId")).toBe("Required");
+});

--- a/src/schema/support-item-rates-schema.ts
+++ b/src/schema/support-item-rates-schema.ts
@@ -1,11 +1,15 @@
+import { optionalRate } from "@/schema/fields";
 import { z } from "zod";
 
+/** A Client's Custom Rate overrides of a Support Item's Day Rates. */
 export const supportItemRatesSchema = z.object({
 	supportItemId: z.string().min(1, "Required"),
-	weekdayRate: z.coerce.number().step(0.01).optional(),
-	weeknightRate: z.coerce.number().step(0.01).optional(),
-	saturdayRate: z.coerce.number().step(0.01).optional(),
-	sundayRate: z.coerce.number().step(0.01).optional()
+	weekdayRate: optionalRate,
+	weeknightRate: optionalRate,
+	saturdayRate: optionalRate,
+	sundayRate: optionalRate
 });
 
 export type SupportItemRatesSchema = z.infer<typeof supportItemRatesSchema>;
+/** The dialog's field values: rates arrive as strings from their inputs. */
+export type SupportItemRatesFormValues = z.input<typeof supportItemRatesSchema>;

--- a/src/schema/support-item-schema.test.ts
+++ b/src/schema/support-item-schema.test.ts
@@ -1,0 +1,76 @@
+import { supportItemSchema } from "@/schema/support-item-schema";
+
+import { expect, test } from "vitest";
+
+/**
+ * The rate fields are fed by number inputs, which hand back strings - so the
+ * schema coerces. These assertions pin the exact message each validation path
+ * shows the Provider, which types alone can't catch.
+ */
+const base = {
+	description: "Assistance with self-care",
+	weekdayCode: "01_011_0107_1_1"
+};
+
+const messageFor = (input: unknown, field: string) => {
+	const result = supportItemSchema.safeParse(input);
+	if (result.success) return undefined;
+	return result.error.issues.find((issue) => issue.path.join(".") === field)
+		?.message;
+};
+
+test("accepts a rate typed as a string", () => {
+	const result = supportItemSchema.safeParse({
+		...base,
+		weekdayRate: "67.56"
+	});
+
+	expect(result.success).toBe(true);
+	expect(result.data?.weekdayRate).toBe(67.56);
+	expect(result.data?.rateType).toBe("HOUR");
+});
+
+test("requires the weekday rate", () => {
+	expect(messageFor(base, "weekdayRate")).toBe("Must be a number");
+	expect(messageFor({ ...base, weekdayRate: "" }, "weekdayRate")).toBe(
+		"Required"
+	);
+	expect(messageFor({ ...base, weekdayRate: 0 }, "weekdayRate")).toBe(
+		"Required"
+	);
+});
+
+test("rejects a non-numeric rate", () => {
+	expect(messageFor({ ...base, weekdayRate: "abc" }, "weekdayRate")).toBe(
+		"Must be a number"
+	);
+	expect(
+		messageFor(
+			{ ...base, weekdayRate: 1, weeknightRate: "abc" },
+			"weeknightRate"
+		)
+	).toBe("Must be a number");
+});
+
+test("rejects more than two decimal places", () => {
+	expect(messageFor({ ...base, weekdayRate: "1.234" }, "weekdayRate")).toBe(
+		"Can't be more than 2 decimal places (x.xx)"
+	);
+	expect(
+		messageFor({ ...base, weekdayRate: 1, sundayRate: 1.234 }, "sundayRate")
+	).toBe("Can't be more than 2 decimal places (x.xx)");
+});
+
+test("rejects a malformed item code", () => {
+	expect(messageFor({ ...base, weekdayCode: "nope" }, "weekdayCode")).toBe(
+		"Must be in format XX_XXX_XXXX_X_X"
+	);
+});
+
+test("leaves the optional rate pairs unset when absent", () => {
+	const result = supportItemSchema.safeParse({ ...base, weekdayRate: 1 });
+
+	expect(result.success).toBe(true);
+	expect(result.data?.weeknightRate).toBeUndefined();
+	expect(result.data?.sundayRate).toBeUndefined();
+});

--- a/src/schema/support-item-schema.ts
+++ b/src/schema/support-item-schema.ts
@@ -1,4 +1,9 @@
 import { RateType } from "@/generated/browser";
+import {
+	numberFromInput,
+	optionalRate,
+	TOO_MANY_DECIMALS_MESSAGE
+} from "@/schema/fields";
 import { z } from "zod";
 
 export const itemCodeRegex = /^\d{2}_(?:\d{3}|\d{9})_\d{4}_\d_\d(?:_T)?$/;
@@ -10,29 +15,26 @@ export const supportItemSchema = z.object({
 	id: z.string().optional(),
 
 	description: z.string().min(1, "Required"),
-	rateType: z.nativeEnum(RateType).default("HOUR"),
+	rateType: z.enum(RateType).default("HOUR"),
 	isGroup: z.boolean().optional(),
 
 	weekdayCode: zodItemCode.min(1, "Required"),
-	weekdayRate: z.coerce
-		.number({ invalid_type_error: "Must be number" })
+	// The weekday pair is the only mandatory one - see CONTEXT.md, Day Rate.
+	weekdayRate: numberFromInput()
 		.min(0.01, "Required")
-		.step(0.01, "Can't be more than 2 decimal places (x.xx)"),
+		.multipleOf(0.01, TOO_MANY_DECIMALS_MESSAGE),
 
 	weeknightCode: zodItemCode.optional().or(z.literal("")),
-	weeknightRate: z.coerce
-		.number({ invalid_type_error: "Must be a number" })
-		.step(0.01, "Can't be more than 2 decimal places (x.xx)")
-		.optional(),
+	weeknightRate: optionalRate,
 	saturdayCode: zodItemCode.optional().or(z.literal("")),
-	saturdayRate: z.coerce
-		.number({ invalid_type_error: "Must be a number" })
-		.step(0.01, "Can't be more than 2 decimal places (x.xx)")
-		.optional(),
+	saturdayRate: optionalRate,
 	sundayCode: zodItemCode.optional().or(z.literal("")),
-	sundayRate: z.coerce
-		.number({ invalid_type_error: "Must be a number" })
-		.step(0.01, "Can't be more than 2 decimal places (x.xx)")
-		.optional()
+	sundayRate: optionalRate
 });
 export type SupportItemSchema = z.infer<typeof supportItemSchema>;
+/**
+ * The form's field values: rates arrive as strings from their number inputs and
+ * `rateType` is filled in by its default, so the input shape differs from the
+ * parsed output.
+ */
+export type SupportItemFormValues = z.input<typeof supportItemSchema>;

--- a/src/schema/user-schema.ts
+++ b/src/schema/user-schema.ts
@@ -1,25 +1,25 @@
+import { numberFromInput } from "@/schema/fields";
 import { z } from "zod";
 
 export const userSchema = z.object({
 	name: z.string().optional(),
 	defaultSupportItemId: z.string().optional(),
 	defaultGroupSupportItemId: z.string().optional(),
-	abn: z.coerce
-		.number()
+	abn: numberFromInput()
 		.min(10_000_000_000, "Must be 11 digits")
 		.max(99_999_999_999, "Must be 11 digits")
 		.optional(),
 	bankName: z.string().optional(),
-	bankNumber: z.coerce.number().optional(),
-	bsb: z.coerce
-		.number()
+	bankNumber: numberFromInput().optional(),
+	bsb: numberFromInput()
 		.min(100_000, "Must be 6 digits")
 		.max(999_999, "Must be 6 digits")
 		.optional(),
-	transitRatePerKm: z.coerce
-		.number()
+	transitRatePerKm: numberFromInput()
 		.min(0, "Must be positive")
 		.max(0.99, "Maximum $0.99/km")
 		.optional()
 });
 export type UserSchema = z.infer<typeof userSchema>;
+/** The account form's field values: numbers arrive as strings from their inputs. */
+export type UserFormValues = z.input<typeof userSchema>;

--- a/src/server/api/routers/invoice-router.ts
+++ b/src/server/api/routers/invoice-router.ts
@@ -350,7 +350,7 @@ export const invoiceRouter = router({
 	list: authedProcedure
 		.input(
 			baseListQueryInput.extend({
-				status: z.nativeEnum(InvoiceStatus).array().optional(),
+				status: z.enum(InvoiceStatus).array().optional(),
 				clientId: z.string().optional(),
 				search: z.string().optional()
 			})


### PR DESCRIPTION
Closes #447.

Zod `3.24.2` -> exact-pinned `4.4.3`, fully v4-native: no `nativeEnum`, `invalid_type_error`, `required_error`, `.step()`, `.string().email()/.url()`, `ZodIssueCode`, `errorMap` or `ZodTypeAny` left anywhere in `src`, `e2e`, `prisma` or `scripts`.

Beyond the issue's inventory, two spots needed the same treatment to hit the idiom-clean bar: `log-schema.ts` (`required_error`) and `multi-activity-form-model.ts` (`z.ZodIssueCode.custom` -> `"custom"`), plus `src/env/schema.js`.

Work item 4 confirmed: all three `.default()`s take literal output-type values, so no `.prefault()`; the three `.refine`s are signature-compatible and untouched.

## `@hookform/resolvers` 4.1.3 -> 5.5.7 was required

The issue assumed resolvers 4 binds to Zod through Standard Schema. It does not: its `zodResolver` reads `error.errors` / `unionErrors` (v3-only internals) and types itself off `z.ZodSchema<T, any, any>`, so it breaks silently on Zod 4. Resolvers 5 dispatches on `_zod` vs `_def` and supports both majors.

That bump, not the zod bump, drives most of this diff. Resolvers 5 types a form's field values from the schema's **input** type, so the four forms whose input shape differs from their output shape now declare `useForm<Input, unknown, Output>` against new exported `*FormValues` types, and the two child components that take `Control`/`UseFormSetValue` follow suit.

## `z.coerce.number()` infers `unknown` as its input type in v4

Left alone, that would type every rate / ABN / BSB form field `unknown`. Fixed with the native idiom `z.coerce.number<string | number>()`, collected in a new `src/schema/fields.ts` along with `optionalRate` and `requiredDate` (the three shapes were otherwise duplicated across four schema files).

`requiredDate` returns `undefined` from its error callback for non-missing input. The issue's literal `z.date({ error: "Date is required" })` would have leaked that message onto wrong-type input too, since a schema-level `error` in v4 replaces every message from that schema; this reproduces v3's `required_error` exactly.

## Message text

Verified rather than eyeballed: every pre-migration schema shape was run against the `zod/v3` subpath and every post-migration shape against v4, over 40 inputs, and the messages diffed. **Every author-written message is byte-identical.** The remaining differences are Zod's own default wording (`Invalid email` -> `Invalid email address`, enum and date type errors), plus two deliberate changes:

- `support-item-rates-schema.ts` had no custom messages at all, so the Custom Rate dialog was showing raw Zod defaults. It now shows the same authored messages as the Support Item form.
- `weekdayRate` said `"Must be number"` while its three siblings in the same form said `"Must be a number"`. Unified to `"Must be a number"`. This is the one deviation from "message text unchanged" - easy to revert if unwanted.

## Verification

- `tsc --noEmit` clean; lint 0 errors; prettier clean.
- Unit 239 passing, integration 143 passing, e2e 29 passing.
- The issue's manual gate is automated instead: new unit tests pin the exact message on every validation path of both rate schemas and the activity date, and a new e2e case asserts the messages as rendered in the real Support Item form.

## Pre-existing bug found, not fixed here

The Custom Rate dialog submits all four rate inputs, so a blank one arrives as `""` and coerces to `0` - persisting a $0 Custom Rate that then wins over the Support Item's own rate, day type by day type. Zod 3 did the same; this is not a regression. `src/schema/fields.ts` documents the coercion honestly and `support-item-rates-schema.test.ts` pins it in a test explicitly labelled current-not-desired behaviour. Worth its own issue.

## Note for local e2e runs

`e2e/navigation.test.ts` fails locally unless `NEXTAUTH_URL` is set, because the landing page's `getSession` needs an absolute URL server-side. This reproduces on a clean `main` and is unrelated to this change. CI sets the variable.
