### PR TITLE
feat: restyle invoice detail page onto the activity-page layout grammar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Never add tool/author attribution to commits, PRs, or issues. Overrides default 
 
 ### Plan management
 
-Numbered, referenceable plans live in `docs/plans/`, indexed in `docs/plans/README.md`. See the `manage-plans` skill.
+Plans live as GitHub issues in this repo, alongside the issue tracker below - `docs/plans/` no longer exists.
 
 ### Issue tracker
 

--- a/e2e/invoice-page.test.ts
+++ b/e2e/invoice-page.test.ts
@@ -1,0 +1,92 @@
+import prisma from "@/server/prisma";
+import { expect, test } from "@playwright/test";
+import { randomInvoice } from "./random/random-invoice";
+import {
+	createRandomActivity,
+	createRandomClient,
+	createRandomSupportItem,
+	testUser,
+	waitForAlert
+} from "./test-utils";
+
+/** Seeds a draft invoice holding one timed activity, directly via Prisma. */
+async function seedDraftInvoice() {
+	const client = await createRandomClient();
+	const supportItem = await createRandomSupportItem();
+	const activity = await createRandomActivity(client.id, supportItem.id, {
+		startTime: "09:00",
+		endTime: "10:00"
+	});
+
+	const invoice = await prisma.invoice.create({
+		data: {
+			invoiceNo: randomInvoice().invoiceNo,
+			date: new Date(),
+			clientId: client.id,
+			ownerId: testUser.id,
+			activities: { connect: { id: activity.id } }
+		}
+	});
+
+	return { invoice, client, supportItem };
+}
+
+test("Can delete a draft invoice from its detail page", async ({ page }) => {
+	const { invoice } = await seedDraftInvoice();
+
+	await page.goto(`/dashboard/invoices/${invoice.id}`);
+	await expect(
+		page.getByRole("heading", { name: invoice.invoiceNo, exact: true })
+	).toBeVisible();
+
+	page.once("dialog", (dialog) => {
+		dialog.accept().catch(() => {});
+	});
+	await page.getByRole("button", { name: "Invoice actions" }).click();
+	await page.getByRole("menuitem", { name: "Delete" }).click();
+
+	await waitForAlert(page, "Invoice deleted");
+	await expect(page).toHaveURL("/dashboard/invoices");
+	await expect(
+		page.getByRole("row").filter({ hasText: invoice.invoiceNo })
+	).toHaveCount(0);
+});
+
+test("Can mark a paid invoice as unpaid from its detail page", async ({
+	page
+}) => {
+	const { invoice } = await seedDraftInvoice();
+
+	await page.goto(`/dashboard/invoices/${invoice.id}`);
+	await page.getByRole("button", { name: "Mark as Sent" }).click();
+	await page.getByRole("button", { name: "Mark as Paid" }).click({
+		timeout: 10000
+	});
+
+	// Paid: Amend is the primary button, Mark as unpaid lives in the overflow
+	await expect(page.getByRole("button", { name: "Amend" })).toBeVisible({
+		timeout: 10000
+	});
+	await page.getByRole("button", { name: "Invoice actions" }).click();
+	await page.getByRole("menuitem", { name: "Mark as unpaid" }).click();
+
+	await expect(page.getByRole("button", { name: "Mark as Paid" })).toBeVisible({
+		timeout: 10000
+	});
+});
+
+test("Invoice activities are visible on a phone-sized viewport", async ({
+	page
+}) => {
+	const { invoice, supportItem } = await seedDraftInvoice();
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto(`/dashboard/invoices/${invoice.id}`);
+
+	await expect(
+		page.getByRole("heading", { name: "Activities · 1" })
+	).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: supportItem.description })
+	).toBeVisible();
+});

--- a/e2e/invoice-versioning.test.ts
+++ b/e2e/invoice-versioning.test.ts
@@ -68,7 +68,7 @@ test("Invoice versioning journey: draft → send → amend → edit → re-send 
 	await page.getByRole("button", { name: "Download" }).click();
 	await page.getByRole("menuitem", { name: "Send & download" }).click();
 
-	await expect(page.getByRole("button", { name: "Amend" })).toBeVisible({
+	await expect(page.getByRole("button", { name: "Mark as Paid" })).toBeVisible({
 		timeout: 10000
 	});
 	await expect(
@@ -86,11 +86,12 @@ test("Invoice versioning journey: draft → send → amend → edit → re-send 
 	expect(v1Text).not.toContain("DRAFT");
 	expect(v1Text).not.toContain("supersedes");
 
-	// --- Amend: confirm dialog, unlocks back to draft ---
+	// --- Amend (in the overflow menu): confirm dialog, unlocks back to draft ---
 	page.once("dialog", (dialog) => {
 		dialog.accept().catch(() => {});
 	});
-	await page.getByRole("button", { name: "Amend" }).click();
+	await page.getByRole("button", { name: "Invoice actions" }).click();
+	await page.getByRole("menuitem", { name: "Amend" }).click();
 	await expect(page.getByRole("button", { name: "Mark as Sent" })).toBeVisible({
 		timeout: 10000
 	});
@@ -110,7 +111,7 @@ test("Invoice versioning journey: draft → send → amend → edit → re-send 
 	// --- Re-send: freezes v2 with the supersedes line ---
 	await page.goto(`/dashboard/invoices/${invoiceId}`);
 	await page.getByRole("button", { name: "Mark as Sent" }).click();
-	await expect(page.getByRole("button", { name: "Amend" })).toBeVisible({
+	await expect(page.getByRole("button", { name: "Mark as Paid" })).toBeVisible({
 		timeout: 10000
 	});
 	await expect(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,7 +39,9 @@ const eslintConfig = defineConfig([
 		"next-env.d.ts",
 		// Playwright artifacts (bundled report/trace JS trips dozens of rules):
 		"playwright-report/**",
-		"test-results/**"
+		"test-results/**",
+		// Agent worktrees (each is a full checkout with its own .next build):
+		".claude/worktrees/**"
 	])
 ]);
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@auth/prisma-adapter": "2.11.2",
 		"@base-ui/react": "1.6.0",
 		"@date-fns/tz": "1.5.0",
-		"@headlessui/react": "2.2.10",
 		"@hookform/resolvers": "5.5.7",
 		"@prisma/adapter-pg": "7.8.0",
 		"@prisma/client": "7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@date-fns/tz':
         specifier: 1.5.0
         version: 1.5.0
-      '@headlessui/react':
-        specifier: 2.2.10
-        version: 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@hookform/resolvers':
         specifier: 5.5.7
         version: 5.5.7(@standard-schema/spec@1.1.0)(ajv@8.20.0)(effect@3.20.0)(react-hook-form@7.80.0(react@19.2.7))(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -977,21 +974,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.28':
-    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@headlessui/react@2.2.10':
-    resolution: {integrity: sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -1249,15 +1233,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@internationalized/date@3.12.2':
-    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
-
-  '@internationalized/number@3.6.7':
-    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
-
-  '@internationalized/string@3.2.9':
-    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2683,23 +2658,6 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
-  '@react-aria/focus@3.22.1':
-    resolution: {integrity: sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/interactions@3.28.1':
-    resolution: {integrity: sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.36.0':
-    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -2861,9 +2819,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/helpers@0.5.23':
-    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
-
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
@@ -2971,18 +2926,9 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.14.3':
-    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
-
-  '@tanstack/virtual-core@3.17.1':
-    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5143,12 +5089,6 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-aria@3.50.0:
-    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   react-day-picker@9.13.2:
     resolution: {integrity: sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg==}
     engines: {node: '>=18'}
@@ -5205,11 +5145,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-stately@3.48.0:
-    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -5530,9 +5465,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tabbable@6.5.0:
-    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -6562,25 +6494,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@floating-ui/react@0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@floating-ui/utils': 0.2.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      tabbable: 6.5.0
-
   '@floating-ui/utils@0.2.11': {}
-
-  '@headlessui/react@2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/focus': 3.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-virtual': 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      use-sync-external-store: 1.6.0(react@19.2.7)
 
   '@hono/node-server@1.19.11(hono@4.12.26)':
     dependencies:
@@ -6706,18 +6620,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
-
-  '@internationalized/date@3.12.2':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
-  '@internationalized/number@3.6.7':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
-  '@internationalized/string@3.2.9':
-    dependencies:
-      '@swc/helpers': 0.5.23
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -8153,25 +8055,6 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@react-aria/focus@3.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@swc/helpers': 0.5.23
-      react: 19.2.7
-      react-aria: 3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-
-  '@react-aria/interactions@3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.36.0(react@19.2.7)
-      '@swc/helpers': 0.5.23
-      react: 19.2.7
-      react-aria: 3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-
-  '@react-types/shared@3.36.0(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
@@ -8265,10 +8148,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/helpers@0.5.23':
-    dependencies:
-      tslib: 2.8.1
-
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -8351,15 +8230,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-virtual@3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@tanstack/virtual-core': 3.17.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@tanstack/table-core@8.21.3': {}
-
-  '@tanstack/virtual-core@3.17.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10778,20 +10649,6 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  react-aria@3.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.36.0(react@19.2.7)
-      '@swc/helpers': 0.5.23
-      aria-hidden: 1.2.6
-      clsx: 2.1.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-stately: 3.48.0(react@19.2.7)
-      use-sync-external-store: 1.6.0(react@19.2.7)
-
   react-day-picker@9.13.2(react@19.2.7):
     dependencies:
       '@date-fns/tz': 1.5.0
@@ -10847,16 +10704,6 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
-
-  react-stately@3.48.0(react@19.2.7):
-    dependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.36.0(react@19.2.7)
-      '@swc/helpers': 0.5.23
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
 
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -11251,8 +11098,6 @@ snapshots:
     optional: true
 
   symbol-tree@3.2.4: {}
-
-  tabbable@6.5.0: {}
 
   tailwind-merge@3.6.0: {}
 

--- a/src/components/activities/activity-breakdown.tsx
+++ b/src/components/activities/activity-breakdown.tsx
@@ -9,13 +9,8 @@ import {
 	type BillableActivity,
 	type TransitRateContext
 } from "@/lib/billing-lines";
+import { formatCurrency } from "@/lib/utils";
 import { Info } from "lucide-react";
-
-const formatCurrency = (value: number) =>
-	value.toLocaleString(undefined, {
-		style: "currency",
-		currency: "AUD"
-	});
 
 const suffixLabel = (suffix?: string) => (suffix ? `/${suffix}` : "");
 

--- a/src/components/activities/activity-page.tsx
+++ b/src/components/activities/activity-page.tsx
@@ -1,5 +1,6 @@
 import ActivityBreakdown from "@/components/activities/activity-breakdown";
 import ActivityTripSummary from "@/components/activities/activity-trip-summary";
+import { Fact, FactGrid } from "@/components/shared/fact";
 import { useRateContext } from "@/components/shared/use-rate-context";
 import { Badge, InvoiceStatusBadge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,8 +27,6 @@ import {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
 import { toast } from "react-toastify";
 
 import { utcDate } from "@/lib/date-utils";
@@ -40,26 +39,6 @@ const formatDuration = (minutes: number) => {
 	if (mins === 0) return `${hours} hr`;
 	return `${hours} hr ${mins} min`;
 };
-
-function Fact({
-	icon: Icon,
-	label,
-	children
-}: {
-	icon: LucideIcon;
-	label: string;
-	children: ReactNode;
-}) {
-	return (
-		<div className="flex flex-col gap-1 px-4 py-3">
-			<dt className="text-foreground/50 flex items-center gap-1.5 text-xs font-medium tracking-wide uppercase">
-				<Icon className="h-3.5 w-3.5" />
-				{label}
-			</dt>
-			<dd className="text-sm font-medium">{children}</dd>
-		</div>
-	);
-}
 
 const ActivityPage = ({ activityId }: { activityId: string }) => {
 	const router = useRouter();
@@ -81,7 +60,7 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 					router.push("/dashboard/activities");
 				})
 				.catch(() => {
-					toast.error("An error occured. Please refresh and try again.");
+					toast.error("An error occurred. Please refresh and try again.");
 				});
 	};
 
@@ -185,7 +164,7 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 						</div>
 					</div>
 
-					<dl className="bg-card grid grid-cols-1 divide-y overflow-hidden rounded-xl border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+					<FactGrid>
 						{hasTimes ? (
 							<Fact icon={Clock} label="Time">
 								{format(utcDate(activity.startTime ?? new Date(0)), "h:mmaaa")}{" "}
@@ -225,7 +204,7 @@ const ActivityPage = ({ activityId }: { activityId: string }) => {
 								<Badge variant="secondary">Pending</Badge>
 							)}
 						</Fact>
-					</dl>
+					</FactGrid>
 				</header>
 
 				<ActivityBreakdown

--- a/src/components/clients/client-page.tsx
+++ b/src/components/clients/client-page.tsx
@@ -48,7 +48,7 @@ const ClientPage = ({ clientId }: { clientId: string }) => {
 					toast.error(
 						error instanceof Error
 							? error.message
-							: "An error occured. Please refresh and try again."
+							: "An error occurred. Please refresh and try again."
 					);
 				});
 	};

--- a/src/components/invoices/invoice-activities.tsx
+++ b/src/components/invoices/invoice-activities.tsx
@@ -1,0 +1,59 @@
+import { utcDate } from "@/lib/date-utils";
+import type { InvoiceByIdOutput } from "@/server/api/routers/invoice-router";
+import { format } from "date-fns";
+import Link from "next/link";
+
+const activityDetail = (activity: InvoiceByIdOutput["activities"][number]) => {
+	const date = format(utcDate(activity.date), "EEEE d MMM yyyy");
+
+	if (activity.startTime && activity.endTime) {
+		return `${date} · ${format(utcDate(activity.startTime), "h:mmaaa")} - ${format(
+			utcDate(activity.endTime),
+			"h:mmaaa"
+		)}`;
+	}
+	if (activity.itemDistance) {
+		return `${date} · ${activity.itemDistance} km`;
+	}
+	return date;
+};
+
+/**
+ * The activities billed on this invoice - straight off `invoice.byId`, so no
+ * second query, and rendered at every viewport.
+ */
+function InvoiceActivities({ invoice }: { invoice: InvoiceByIdOutput }) {
+	return (
+		<section className="bg-card overflow-hidden rounded-xl border">
+			<div className="border-b px-5 py-3.5">
+				<h2 className="text-sm font-semibold">
+					Activities · {invoice.activities.length}
+				</h2>
+			</div>
+
+			{invoice.activities.length === 0 ? (
+				<p className="text-foreground/50 px-5 py-4 text-sm">
+					No activities on this invoice yet.
+				</p>
+			) : (
+				<div className="divide-y px-5">
+					{invoice.activities.map((activity) => (
+						<div key={activity.id} className="flex flex-col gap-0.5 py-4">
+							<Link
+								href={`/dashboard/activities/${activity.id}`}
+								className="decoration-foreground/30 hover:decoration-foreground w-fit text-sm font-medium underline underline-offset-4 transition-colors"
+							>
+								{activity.supportItem.description}
+							</Link>
+							<p className="text-foreground/60 text-xs">
+								{activityDetail(activity)}
+							</p>
+						</div>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}
+
+export default InvoiceActivities;

--- a/src/components/invoices/invoice-document.tsx
+++ b/src/components/invoices/invoice-document.tsx
@@ -1,0 +1,134 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import {
+	useDownloadInvoicePdf,
+	useInvalidateInvoice
+} from "@/components/invoices/use-invoice-actions";
+import { InvoiceStatus } from "@/generated/browser";
+import { currentDisplayInvoiceNo } from "@/lib/invoice-utils";
+import { trpc } from "@/lib/trpc";
+import type { InvoiceByIdOutput } from "@/server/api/routers/invoice-router";
+import { ChevronDown, Download, Search } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+
+const PdfPreview = dynamic(() => import("@/components/invoices/pdf-preview"), {
+	ssr: false
+});
+
+/**
+ * The invoice's rendered PDF: a thumbnail that expands into a full preview,
+ * plus the download actions. A draft with activities gets the Download split
+ * (draft copy vs send & download); everything else downloads what the server
+ * resolves for the invoice - the DRAFT watermark for drafts, the frozen
+ * latest version once sent.
+ */
+function InvoiceDocument({ invoice }: { invoice: InvoiceByIdOutput }) {
+	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+	const sendMutation = trpc.invoice.send.useMutation();
+	const invalidateInvoice = useInvalidateInvoice(invoice.id);
+	const downloadPdf = useDownloadInvoicePdf(invoice.id);
+
+	const isDraft = invoice.status === InvoiceStatus.CREATED;
+	const hasActivities = invoice.activities.length > 0;
+
+	// A locked invoice's download is the frozen latest version, so name the
+	// file after it; a draft renders under the bare invoice number.
+	const currentFileName = isDraft
+		? invoice.invoiceNo
+		: currentDisplayInvoiceNo(invoice);
+
+	const sendAndDownload = async () => {
+		const { invoices } = await sendMutation.mutateAsync({ ids: [invoice.id] });
+
+		// Let the refetch land before the (slow) PDF fetch starts - issued in
+		// the same tick they'd share an HTTP batch, and the page would sit on
+		// stale draft actions until the PDF render finished.
+		await invalidateInvoice();
+
+		await downloadPdf(currentDisplayInvoiceNo(invoices[0] ?? invoice));
+	};
+
+	return (
+		<section className="bg-card overflow-hidden rounded-xl border">
+			<div className="flex items-center justify-between gap-2 border-b px-5 py-3.5">
+				<h2 className="text-sm font-semibold">Document</h2>
+
+				{isDraft && hasActivities ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="outline" size="sm">
+								<Download />
+								Download
+								<ChevronDown />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem
+								className="cursor-pointer"
+								onClick={() => downloadPdf(currentFileName)}
+							>
+								Download draft
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="cursor-pointer"
+								onClick={sendAndDownload}
+							>
+								Send & download
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => downloadPdf(currentFileName)}
+					>
+						<Download />
+						Download
+					</Button>
+				)}
+			</div>
+
+			{hasActivities ? (
+				<div className="group bg-foreground/10 relative h-48 cursor-pointer overflow-hidden shadow-inner">
+					<div className="pointer-events-none absolute inset-0 flex justify-center overflow-hidden">
+						<div className="w-full">
+							<PdfPreview invoiceId={invoice.id} />
+						</div>
+					</div>
+					<div
+						className="absolute inset-0 flex items-center justify-center"
+						onClick={() => setIsPreviewOpen(true)}
+						data-testid="pdf-preview-trigger"
+					>
+						<div className="flex items-center justify-center gap-2 rounded-md bg-zinc-900/80 px-3 py-2 text-zinc-50 transition-transform group-hover:scale-110 group-hover:bg-zinc-900">
+							<Search className="h-4 w-4" />
+							Preview
+						</div>
+					</div>
+				</div>
+			) : (
+				<div className="bg-foreground/10 flex h-48 items-center justify-center">
+					<p className="text-foreground/50 text-4xl">DRAFT</p>
+				</div>
+			)}
+
+			<Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+				<DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto p-0">
+					<DialogTitle className="sr-only">Invoice preview</DialogTitle>
+					<PdfPreview invoiceId={invoice.id} />
+				</DialogContent>
+			</Dialog>
+		</section>
+	);
+}
+
+export default InvoiceDocument;

--- a/src/components/invoices/invoice-page.tsx
+++ b/src/components/invoices/invoice-page.tsx
@@ -1,3 +1,8 @@
+import InvoiceActivities from "@/components/invoices/invoice-activities";
+import InvoiceDocument from "@/components/invoices/invoice-document";
+import InvoiceVersionHistory from "@/components/invoices/invoice-version-history";
+import { useInvalidateInvoice } from "@/components/invoices/use-invoice-actions";
+import { Fact, FactGrid } from "@/components/shared/fact";
 import { useRateContext } from "@/components/shared/use-rate-context";
 import { InvoiceStatusBadge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -7,41 +12,31 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import Heading from "@/components/ui/heading";
 import Loading from "@/components/ui/loading";
-import { getTotalCostOfActivities } from "@/lib/activity-utils";
-import { downloadOrSharePdf } from "@/lib/download-pdf";
-import { trpc } from "@/lib/trpc";
-import { cn } from "@/lib/utils";
-import { Dialog, DialogPanel, Transition } from "@headlessui/react";
 import { InvoiceStatus } from "@/generated/browser";
+import { getTotalCostOfActivities } from "@/lib/activity-utils";
 import { utcDate } from "@/lib/date-utils";
+import { currentDisplayInvoiceNo } from "@/lib/invoice-utils";
+import { trpc } from "@/lib/trpc";
+import { formatCurrency } from "@/lib/utils";
 import { format } from "date-fns";
 import {
-	ChevronDown,
-	Clock,
 	DollarSign,
-	Download,
 	Dumbbell,
+	EllipsisVertical,
+	Pencil,
 	Plane,
-	Search,
 	Trash2,
 	Undo,
 	User
 } from "lucide-react";
-import dynamic from "next/dynamic";
+import Head from "next/head";
 import Link from "next/link";
-import { Fragment, useState } from "react";
-
-const PdfPreview = dynamic(() => import("@/components/invoices/pdf-preview"), {
-	ssr: false
-});
-const ActivityList = dynamic(
-	() => import("@/components/activities/activity-list")
-);
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
 
 const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
-	const [isPdfPreviewExpanded, setIsPdfPreviewExpanded] = useState(false);
+	const router = useRouter();
 	const rateContext = useRateContext();
 
 	const trpcUtils = trpc.useUtils();
@@ -51,19 +46,22 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 	const sendMutation = trpc.invoice.send.useMutation();
 	const amendMutation = trpc.invoice.amend.useMutation();
 	const markPaidMutation = trpc.invoice.markPaid.useMutation();
-	const deleteVersionMutation = trpc.invoice.deleteVersion.useMutation();
-
-	const invalidateInvoice = () => {
-		trpcUtils.invoice.byId.invalidate({ id: invoiceId });
-		trpcUtils.invoice.list.invalidate();
-	};
+	const unmarkPaidMutation = trpc.invoice.unmarkPaid.useMutation();
+	const deleteMutation = trpc.invoice.delete.useMutation();
+	const invalidateInvoice = useInvalidateInvoice(invoiceId);
 
 	const sendInvoice = () => {
 		sendMutation.mutateAsync({ ids: [invoiceId] }).then(invalidateInvoice);
 	};
 
-	const markInvoiceAsPaid = () => {
+	const markAsPaid = () => {
 		markPaidMutation.mutateAsync({ ids: [invoiceId] }).then(invalidateInvoice);
+	};
+
+	const markAsUnpaid = () => {
+		unmarkPaidMutation
+			.mutateAsync({ ids: [invoiceId] })
+			.then(invalidateInvoice);
 	};
 
 	const amendInvoice = () => {
@@ -72,39 +70,20 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 		amendMutation.mutateAsync({ id: invoiceId }).then(invalidateInvoice);
 	};
 
-	const deleteVersion = (versionNumber: number, isOnly: boolean) => {
-		const message = isOnly
-			? "Delete this version? The invoice will return to draft, as if it was never sent."
-			: "Delete this version? It will be dropped and its number reused on the next send.";
-		if (!confirm(message)) return;
+	const deleteInvoice = () => {
+		if (!confirm("Delete this invoice? This can't be undone.")) return;
 
-		deleteVersionMutation
-			.mutateAsync({ id: invoiceId, versionNumber })
-			.then(invalidateInvoice);
-	};
-
-	// Draft downloads carry a DRAFT watermark; a sent
-	// invoice's download is the frozen version the server resolves.
-	const downloadInvoicePdf = async (versionNumber?: number) => {
-		const dataUrl = await trpcUtils.pdf.forInvoice.fetch({
-			invoiceId,
-			returnBase64: true,
-			versionNumber
-		});
-
-		const displayNo = versionNumber
-			? (invoice?.versions?.find((v) => v.versionNumber === versionNumber)
-					?.displayInvoiceNo ?? invoice?.invoiceNo)
-			: invoice?.invoiceNo;
-
-		await downloadOrSharePdf(dataUrl, `${displayNo}.pdf`);
-	};
-
-	const sendAndDownloadInvoice = () => {
-		sendMutation.mutateAsync({ ids: [invoiceId] }).then(() => {
-			invalidateInvoice();
-			downloadInvoicePdf();
-		});
+		deleteMutation
+			.mutateAsync({ id: invoiceId })
+			.then(() => {
+				// Only the list - the detail query would refetch a gone invoice.
+				trpcUtils.invoice.list.invalidate();
+				toast.success("Invoice deleted");
+				router.push("/dashboard/invoices");
+			})
+			.catch(() => {
+				toast.error("An error occurred. Please refresh and try again.");
+			});
 	};
 
 	if (error) {
@@ -113,256 +92,147 @@ const InvoicePage = ({ invoiceId }: { invoiceId: string }) => {
 	}
 	if (!invoice) return <Loading />;
 
+	const isDraft = invoice.status === InvoiceStatus.CREATED;
+	const isSent = invoice.status === InvoiceStatus.SENT;
+	const isPaid = invoice.status === InvoiceStatus.PAID;
+	const hasVersions = (invoice.versions?.length ?? 0) > 0;
+
+	const displayNo = currentDisplayInvoiceNo(invoice);
+
+	// A draft's total tracks live rates; a locked invoice shows the latest
+	// version's frozen total, not a recompute.
+	const total = isDraft
+		? getTotalCostOfActivities(invoice.activities, rateContext, {
+				forDisplay: true
+			})
+		: (invoice.versions?.[0]?.total ?? 0);
+
 	return (
-		<div className="mx-auto flex w-full max-w-5xl flex-col">
-			<Transition
-				show={isPdfPreviewExpanded}
-				as={Fragment}
-				enter="ease-out duration-300"
-				enterFrom="opacity-0"
-				enterTo="opacity-100"
-				leave="ease-in duration-200"
-				leaveFrom="opacity-100"
-				leaveTo="opacity-0"
-			>
-				<Dialog
-					onClose={() => setIsPdfPreviewExpanded(false)}
-					className="relative z-50"
-				>
-					<div
-						className="fixed inset-0 bg-black/30"
-						aria-hidden="true"
-						onClick={() => setIsPdfPreviewExpanded(false)}
-					/>
-					<div className="fixed inset-0 box-border flex w-screen justify-center overflow-y-auto">
-						<DialogPanel className="box-border h-full w-full max-w-4xl">
-							<PdfPreview invoiceId={invoice.id} className="my-10" />
-						</DialogPanel>
-					</div>
-				</Dialog>
-			</Transition>
-
-			<div className="flex flex-col items-stretch justify-between md:h-[15rem] md:flex-row-reverse">
-				<div
-					className={cn([
-						"group relative h-full max-h-[12rem] min-h-[12rem] basis-1/2 overflow-hidden md:max-h-[15rem]",
-						invoice.activities.length > 0 &&
-							"bg-foreground/10 cursor-pointer shadow-inner"
-					])}
-				>
-					{invoice.activities.length > 0 ? (
-						<>
-							<div className="pointer-events-none absolute inset-0 flex justify-center overflow-hidden">
-								<div className="w-full">
-									<PdfPreview invoiceId={invoice.id} />
-								</div>
+		<div className="flex flex-col items-center px-4 pb-24 md:pb-8">
+			<Head>
+				<title>{`${displayNo} | Melvin`}</title>
+			</Head>
+			<div className="flex w-full max-w-3xl flex-col gap-6">
+				<header className="mt-2 flex flex-col gap-5">
+					<div className="flex items-start justify-between gap-3">
+						<div className="flex min-w-0 flex-col gap-1">
+							<p className="text-primary text-xs font-medium">
+								{format(utcDate(invoice.date), "EEEE, d MMMM yyyy")}
+							</p>
+							<div className="flex items-center gap-2.5">
+								<h1 className="text-lg font-semibold tracking-tight text-balance md:text-xl">
+									{displayNo}
+								</h1>
+								<InvoiceStatusBadge invoiceStatus={invoice.status} />
 							</div>
-							<div
-								className="absolute top-0 right-0 flex h-full w-full items-center justify-center"
-								onClick={() => setIsPdfPreviewExpanded(true)}
-								data-testid="pdf-preview-trigger"
-							>
-								<div className="flex items-center justify-center gap-2 rounded-md bg-zinc-900/80 px-4 py-3 text-zinc-50 transition-transform group-hover:scale-110 group-hover:bg-zinc-900 md:px-3 md:py-2 md:text-lg">
-									<Search className="h-4 w-4" />
-									Preview
-								</div>
-							</div>
-						</>
-					) : (
-						<div className="bg-foreground/10 flex h-full w-full items-center justify-center md:h-[15rem]">
-							<p className="text-foreground/50 text-4xl">DRAFT</p>
+							<p className="text-foreground/50 font-mono text-xs">
+								Bill to {invoice.billTo ?? invoice.client.name}
+							</p>
 						</div>
-					)}
-				</div>
-				<div className="mx-auto flex w-full basis-1/2 flex-col px-4 py-4 md:pt-0">
-					<div className="flex items-center justify-between md:mb-5">
-						<Heading className="py-3">
-							{invoice.versions?.[0]?.displayInvoiceNo ?? invoice.invoiceNo}
-						</Heading>
-						{invoice.status === InvoiceStatus.CREATED && (
-							<Link
-								href={`/dashboard/invoices/${invoice.id}/edit`}
-								className="px-4 py-3 text-sm"
-							>
-								EDIT
-							</Link>
-						)}
-					</div>
-					<p className="text-foreground/80 text-sm">Total</p>
-					<div className="flex items-center justify-between">
-						<p className="text-xl" data-testid="invoice-total">
-							{(invoice.status === InvoiceStatus.CREATED
-								? getTotalCostOfActivities(invoice.activities, rateContext, {
-										forDisplay: true
-									})
-								: (invoice.versions?.[0]?.total ?? 0)
-							).toLocaleString(undefined, {
-								style: "currency",
-								currency: "AUD"
-							})}
-						</p>
-						<InvoiceStatusBadge invoiceStatus={invoice.status} />
-					</div>
 
-					<div className="flex grow flex-col justify-start gap-4">
-						<div className="mt-5 flex justify-center gap-2">
-							{invoice.status === InvoiceStatus.CREATED &&
-								invoice.activities.length > 0 && (
-									<Button onClick={sendInvoice} className="w-1/2 grow">
-										<Plane className="mr-2 h-4 w-4" /> Mark as Sent
-									</Button>
-								)}
-							{invoice.status === InvoiceStatus.SENT && (
+						<div className="flex shrink-0 items-center gap-1.5">
+							{isDraft && (
 								<Button
-									onClick={markInvoiceAsPaid}
-									variant="secondary"
-									className="w-1/2 grow"
+									size="sm"
+									onClick={sendInvoice}
+									disabled={invoice.activities.length === 0}
 								>
-									<DollarSign className="mr-2 h-4 w-4" /> Mark as Paid
+									<Plane />
+									Mark as Sent
 								</Button>
 							)}
-							{(invoice.status === InvoiceStatus.SENT ||
-								invoice.status === InvoiceStatus.PAID) && (
-								<Button
-									onClick={amendInvoice}
-									className="w-1/2 grow"
-									variant="secondary"
-								>
-									<Undo className="mr-2 h-4 w-4" />
+							{isSent && (
+								<Button size="sm" onClick={markAsPaid}>
+									<DollarSign />
+									Mark as Paid
+								</Button>
+							)}
+							{isPaid && (
+								<Button size="sm" onClick={amendInvoice}>
+									<Undo />
 									Amend
 								</Button>
 							)}
-							{invoice.status === InvoiceStatus.CREATED &&
-							invoice.activities.length > 0 ? (
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button variant="secondary" className="w-1/2 grow">
-											<Download className="mr-2 h-4 w-4" />
-											Download
-											<ChevronDown className="ml-2 h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent>
-										<DropdownMenuItem
-											className="cursor-pointer"
-											onClick={() => downloadInvoicePdf()}
-										>
-											Download draft
-										</DropdownMenuItem>
-										<DropdownMenuItem
-											className="cursor-pointer"
-											onClick={sendAndDownloadInvoice}
-										>
-											Send & download
-										</DropdownMenuItem>
-									</DropdownMenuContent>
-								</DropdownMenu>
-							) : (
-								<Button
-									className="w-1/2 grow"
-									onClick={() => downloadInvoicePdf()}
-								>
-									<Download className="mr-2 h-4 w-4" />
-									Download PDF
-								</Button>
-							)}
-						</div>
-						{invoice.sentAt && (
-							<div className="text-foreground/80 flex flex-col gap-1">
-								<p>Sent on: {format(utcDate(invoice.sentAt), "dd/MM/yyyy")}</p>
-							</div>
-						)}
-					</div>
-				</div>
-			</div>
 
-			{invoice.versions && invoice.versions.length > 0 && (
-				<div className="flex w-full flex-col gap-2 p-2 px-4">
-					<p className="font-semibold">Version history</p>
-					{invoice.versions.map((version, index) => (
-						<div
-							key={version.versionNumber}
-							className="flex items-center justify-between rounded-md border p-3"
-						>
-							<div>
-								<p className="font-semibold">{version.displayInvoiceNo}</p>
-								<p className="text-foreground/60 text-sm">
-									Sent {format(utcDate(version.sentAt), "dd/MM/yyyy")}
-									{version.paidAt &&
-										` · Paid ${format(utcDate(version.paidAt), "dd/MM/yyyy")}`}
-									{version.backfilled && " · Backfilled"}
-								</p>
-							</div>
-							<div className="flex items-center gap-3">
-								<p className="font-semibold">
-									{version.total.toLocaleString(undefined, {
-										style: "currency",
-										currency: "AUD"
-									})}
-								</p>
-								<Button
-									variant="ghost"
-									size="icon"
-									onClick={() => downloadInvoicePdf(version.versionNumber)}
-								>
-									<Download className="h-4 w-4" />
-								</Button>
-								{index === 0 && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
 									<Button
 										variant="ghost"
 										size="icon"
-										onClick={() =>
-											deleteVersion(
-												version.versionNumber,
-												invoice.versions!.length === 1
-											)
-										}
-										aria-label="Delete version"
+										aria-label="Invoice actions"
 									>
-										<Trash2 className="text-destructive h-4 w-4" />
+										<EllipsisVertical />
 									</Button>
-								)}
-							</div>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									{isDraft && (
+										<Link href={`/dashboard/invoices/${invoice.id}/edit`}>
+											<DropdownMenuItem className="cursor-pointer">
+												<Pencil className="mr-2 h-4 w-4" />
+												<span>Edit</span>
+											</DropdownMenuItem>
+										</Link>
+									)}
+									{isSent && (
+										<DropdownMenuItem
+											onClick={amendInvoice}
+											className="cursor-pointer"
+										>
+											<Undo className="mr-2 h-4 w-4" />
+											<span>Amend</span>
+										</DropdownMenuItem>
+									)}
+									{isPaid && (
+										<DropdownMenuItem
+											onClick={markAsUnpaid}
+											className="cursor-pointer"
+										>
+											<Undo className="mr-2 h-4 w-4" />
+											<span>Mark as unpaid</span>
+										</DropdownMenuItem>
+									)}
+									{isDraft && !hasVersions && (
+										<DropdownMenuItem
+											onClick={deleteInvoice}
+											className="text-destructive focus:text-destructive cursor-pointer"
+										>
+											<Trash2 className="mr-2 h-4 w-4" />
+											<span>Delete</span>
+										</DropdownMenuItem>
+									)}
+								</DropdownMenuContent>
+							</DropdownMenu>
 						</div>
-					))}
-				</div>
-			)}
-			<div className="flex w-full flex-col justify-between md:flex-row md:pt-6">
-				<div className="flex basis-1/2 flex-col gap-0 p-2 px-4">
-					<p className="font-semibold">Info</p>
-					<div className="flex items-center gap-4 p-2">
-						<Clock className="h-4 w-4" />
-						<p>{format(utcDate(invoice.date), "dd/MM/yyyy")}</p>
 					</div>
-					<Link
-						className="text-fg hover:bg-foreground/15 flex w-full items-center gap-4 rounded-md p-2 text-left"
-						href={`/dashboard/clients/${invoice.client.id}`}
-					>
-						<User className="h-4 w-4" />
-						{invoice.client.name}
-					</Link>
-					<div className="flex items-center gap-4 p-2">
-						<Dumbbell className="h-4 w-4" />
-						<p>
-							{invoice.activities.length} Activit
-							{invoice.activities.length > 1 ? "ies" : "y"}
-						</p>
-					</div>
-					{invoice.paidAt && (
-						<div className="flex items-center gap-4 p-2">
-							<DollarSign className="h-4 w-4" />
-							<p>Paid {format(utcDate(invoice.paidAt), "dd/MM/yyyy")}</p>
-						</div>
-					)}
-				</div>
-			</div>
 
-			<div className="hidden md:mt-8 md:block">
-				<ActivityList
-					groupByAssignedStatus={false}
-					invoiceId={invoice.id}
-					displayCreateButton={false}
-				/>
+					<FactGrid>
+						<Fact icon={DollarSign} label="Total">
+							<span
+								className="text-lg font-semibold tracking-tight tabular-nums"
+								data-testid="invoice-total"
+							>
+								{formatCurrency(total)}
+							</span>
+						</Fact>
+
+						<Fact icon={User} label="Client">
+							<Link
+								href={`/dashboard/clients/${invoice.client.id}`}
+								className="decoration-foreground/30 hover:decoration-foreground underline underline-offset-4 transition-colors"
+							>
+								{invoice.client.name}
+							</Link>
+						</Fact>
+
+						<Fact icon={Dumbbell} label="Activities">
+							{invoice.activities.length}
+						</Fact>
+					</FactGrid>
+				</header>
+
+				<InvoiceDocument invoice={invoice} />
+				<InvoiceVersionHistory invoice={invoice} />
+				<InvoiceActivities invoice={invoice} />
 			</div>
 		</div>
 	);

--- a/src/components/invoices/invoice-version-history.tsx
+++ b/src/components/invoices/invoice-version-history.tsx
@@ -1,0 +1,92 @@
+import {
+	useDownloadInvoicePdf,
+	useInvalidateInvoice
+} from "@/components/invoices/use-invoice-actions";
+import { Button } from "@/components/ui/button";
+import { utcDate } from "@/lib/date-utils";
+import { trpc } from "@/lib/trpc";
+import { formatCurrency } from "@/lib/utils";
+import type { InvoiceByIdOutput } from "@/server/api/routers/invoice-router";
+import { format } from "date-fns";
+import { Download, Trash2 } from "lucide-react";
+
+/**
+ * Every frozen version of the invoice, newest first, each downloadable as it
+ * was sent. Only the latest version can be deleted - dropping an earlier one
+ * would misalign every later version's suffix.
+ */
+function InvoiceVersionHistory({ invoice }: { invoice: InvoiceByIdOutput }) {
+	const deleteVersionMutation = trpc.invoice.deleteVersion.useMutation();
+	const invalidateInvoice = useInvalidateInvoice(invoice.id);
+	const downloadPdf = useDownloadInvoicePdf(invoice.id);
+
+	const versions = invoice.versions ?? [];
+	if (versions.length === 0) return null;
+
+	const deleteVersion = (versionNumber: number) => {
+		const message =
+			versions.length === 1
+				? "Delete this version? The invoice will return to draft, as if it was never sent."
+				: "Delete this version? It will be dropped and its number reused on the next send.";
+		if (!confirm(message)) return;
+
+		deleteVersionMutation
+			.mutateAsync({ id: invoice.id, versionNumber })
+			.then(invalidateInvoice);
+	};
+
+	return (
+		<section className="bg-card overflow-hidden rounded-xl border">
+			<div className="border-b px-5 py-3.5">
+				<h2 className="text-sm font-semibold">Version history</h2>
+			</div>
+
+			<div className="divide-y px-5">
+				{versions.map((version, index) => (
+					<div
+						key={version.versionNumber}
+						className="flex items-center justify-between gap-4 py-3"
+					>
+						<div className="flex min-w-0 flex-col gap-0.5">
+							<p className="text-sm font-medium">{version.displayInvoiceNo}</p>
+							<p className="text-foreground/60 text-xs">
+								Sent {format(utcDate(version.sentAt), "dd/MM/yyyy")}
+								{version.paidAt &&
+									` · Paid ${format(utcDate(version.paidAt), "dd/MM/yyyy")}`}
+								{version.backfilled && " · Backfilled"}
+							</p>
+						</div>
+
+						<div className="flex shrink-0 items-center gap-1">
+							<p className="mr-2 text-sm font-semibold tabular-nums">
+								{formatCurrency(version.total)}
+							</p>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={() =>
+									downloadPdf(version.displayInvoiceNo, version.versionNumber)
+								}
+								aria-label={`Download ${version.displayInvoiceNo}`}
+							>
+								<Download className="h-4 w-4" />
+							</Button>
+							{index === 0 && (
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={() => deleteVersion(version.versionNumber)}
+									aria-label="Delete version"
+								>
+									<Trash2 className="text-destructive h-4 w-4" />
+								</Button>
+							)}
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}
+
+export default InvoiceVersionHistory;

--- a/src/components/invoices/use-invoice-actions.ts
+++ b/src/components/invoices/use-invoice-actions.ts
@@ -1,0 +1,37 @@
+import { downloadOrSharePdf } from "@/lib/download-pdf";
+import { trpc } from "@/lib/trpc";
+
+/**
+ * Invalidates the queries an invoice mutation goes stale against: the
+ * invoice's own detail query and the list. Resolves once active refetches
+ * have landed.
+ */
+export function useInvalidateInvoice(invoiceId: string) {
+	const trpcUtils = trpc.useUtils();
+
+	return async () => {
+		await Promise.all([
+			trpcUtils.invoice.byId.invalidate({ id: invoiceId }),
+			trpcUtils.invoice.list.invalidate()
+		]);
+	};
+}
+
+/**
+ * Downloads (or shares) the invoice's PDF as `<fileName>.pdf` - the frozen
+ * version when a `versionNumber` is given, otherwise whatever the server
+ * resolves for the invoice.
+ */
+export function useDownloadInvoicePdf(invoiceId: string) {
+	const trpcUtils = trpc.useUtils();
+
+	return async (fileName: string, versionNumber?: number) => {
+		const dataUrl = await trpcUtils.pdf.forInvoice.fetch({
+			invoiceId,
+			returnBase64: true,
+			versionNumber
+		});
+
+		await downloadOrSharePdf(dataUrl, `${fileName}.pdf`);
+	};
+}

--- a/src/components/shared/delete-entity-button.tsx
+++ b/src/components/shared/delete-entity-button.tsx
@@ -24,7 +24,7 @@ export const DeleteEntityButton = ({
 					toast.error(
 						error instanceof Error
 							? error.message
-							: "An error occured. Please refresh and try again."
+							: "An error occurred. Please refresh and try again."
 					);
 				});
 		}

--- a/src/components/shared/fact.tsx
+++ b/src/components/shared/fact.tsx
@@ -1,0 +1,34 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * The at-a-glance facts card detail pages lead with: a `<dl>` that stacks on
+ * phones and splits into three columns from `sm` up.
+ */
+export function FactGrid({ children }: { children: ReactNode }) {
+	return (
+		<dl className="bg-card grid grid-cols-1 divide-y overflow-hidden rounded-xl border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+			{children}
+		</dl>
+	);
+}
+
+export function Fact({
+	icon: Icon,
+	label,
+	children
+}: {
+	icon: LucideIcon;
+	label: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-1 px-4 py-3">
+			<dt className="text-foreground/50 flex items-center gap-1.5 text-xs font-medium tracking-wide uppercase">
+				<Icon className="h-3.5 w-3.5" />
+				{label}
+			</dt>
+			<dd className="text-sm font-medium">{children}</dd>
+		</div>
+	);
+}

--- a/src/components/support-items/support-item-page.tsx
+++ b/src/components/support-items/support-item-page.tsx
@@ -32,7 +32,7 @@ const SupportItemPage = ({ supportItemId }: { supportItemId: string }) => {
 					router.push("/dashboard/support-items");
 				})
 				.catch(() => {
-					toast.error("An error occured. Please refresh and try again.");
+					toast.error("An error occurred. Please refresh and try again.");
 				});
 	};
 

--- a/src/lib/invoice-utils.ts
+++ b/src/lib/invoice-utils.ts
@@ -83,6 +83,17 @@ export function displayInvoiceNo(
 	return `${invoiceNo}${invoiceVersionSuffix(versionNumber)}`;
 }
 
+/**
+ * The number an invoice currently trades under: its latest version's display
+ * number once sent, or the stored `invoiceNo` while it has never been sent.
+ */
+export function currentDisplayInvoiceNo(invoice: {
+	invoiceNo: string;
+	versions?: { displayInvoiceNo: string }[];
+}): string {
+	return invoice.versions?.[0]?.displayInvoiceNo ?? invoice.invoiceNo;
+}
+
 export function invoiceCandidatesFromPaymentAmount(
 	paymentAmount: number,
 	invoiceTotals: Map<number, string | string[]>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,17 @@
+import { formatCurrency } from "@/lib/utils";
+import { expect, test } from "vitest";
+
+// The formatter uses the runtime locale, so the currency symbol varies
+// ("$" under en-AU, "A$" under en-US) - assert on the symbol-agnostic tail.
+
+test("formatCurrency renders AUD with cents by default", () => {
+	expect(formatCurrency(1234.5)).toMatch(/^A?\$1,234\.50$/);
+	expect(formatCurrency(0)).toMatch(/^A?\$0\.00$/);
+	expect(formatCurrency(62.17)).toMatch(/^A?\$62\.17$/);
+});
+
+test("formatCurrency drops forced cents when minimumFractionDigits is 0", () => {
+	expect(formatCurrency(1234, 0)).toMatch(/^A?\$1,234$/);
+	// Non-whole values still keep their cents
+	expect(formatCurrency(1234.5, 0)).toMatch(/^A?\$1,234\.5$/);
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,10 +6,14 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-export function decimalToCurrencyString(value: Prisma.Decimal) {
-	return Number(value).toLocaleString(undefined, {
+export function formatCurrency(value: number, minimumFractionDigits = 2) {
+	return value.toLocaleString(undefined, {
 		style: "currency",
 		currency: "AUD",
-		minimumFractionDigits: 0
+		minimumFractionDigits
 	});
+}
+
+export function decimalToCurrencyString(value: Prisma.Decimal) {
+	return formatCurrency(Number(value), 0);
 }

--- a/src/pages/dashboard/account/edit.tsx
+++ b/src/pages/dashboard/account/edit.tsx
@@ -39,7 +39,7 @@ const EditAccountPage = () => {
 				router.reload();
 			})
 			.catch((error) => {
-				toast.error("An error occured. Please try again.");
+				toast.error("An error occurred. Please try again.");
 				console.error(error);
 			});
 	};


### PR DESCRIPTION
Closes #477

Restyles the invoice detail page onto the layout grammar introduced for the activity detail page, and fixes the defects that surfaced along the way.

## Layout

- Centred `max-w-3xl` column: eyebrow date → `h1` (with `InvoiceStatusBadge` as a sibling, keeping the `exact: true` heading assertion green) → `Bill to` mono line
- Fact grid: **Total** (scaled up, live for drafts / frozen version total once locked) · **Client** (link) · **Activities**
- Flat stacked section cards: `Document` · `Version history` · `Activities · n`

## Actions

| Status | Primary | Overflow |
|---|---|---|
| Draft, no versions | Mark as Sent | Edit · Delete |
| Draft, amended | Mark as Sent | Edit |
| Sent | Mark as Paid | Amend |
| Paid | Amend | Mark as unpaid |

Delete is gated on `versions.length === 0`; delete-from-detail and mark-as-unpaid are new here. The Document section owns the PDF actions (Preview, Download split with send & download).

## Defects fixed

- Activities were invisible on mobile (`hidden md:block`) - the new section renders at every viewport, straight off `invoice.byId` (no second `activity.list` query or nested page shell)
- Redundant Info block (sentAt/paidAt only repeated the top version row)
- `@headlessui/react` dropped - the preview uses the repo `Dialog`
- `formatCurrency` extracted to `src/lib/utils.ts` (with unit tests); `decimalToCurrencyString` re-expressed over it
- `0 Activity` pluralisation and the `invoice.versions!` non-null assertion
- Latent send-&-download flake: the `byId` refetch and the slow PDF fetch were issued in the same tick and could share one tRPC HTTP batch, leaving the page on stale draft actions until the PDF rendered - invalidation is now awaited first

## Along the way

- `Fact`/`FactGrid` extracted to `src/components/shared/fact.tsx`; shared `useInvalidateInvoice`/`useDownloadInvoicePdf` hooks and a `currentDisplayInvoiceNo` helper collapse the per-section duplication
- `.claude/worktrees/**` added to eslint ignores (a stale worktree's `.next` build produced ~1900 phantom lint errors)
- Repo-wide "occured" → "occurred" typo sweep
- CLAUDE.md's stale `docs/plans/` reference fixed

## Tests

- `invoice-versioning.test.ts` updated: Amend for a Sent invoice now lives in the overflow menu
- New e2e (`invoice-page.test.ts`): delete-from-detail, mark-as-unpaid, activities visible at 390px
- Unit tests for `formatCurrency`; `invoice-total`, `pdf-preview-trigger` and `pdf-preview` test ids carried over

Typecheck, lint, prettier and all 229 unit tests pass; the invoice e2e files pass in isolation. The full e2e suite wasn't run to completion locally (a parallel suite shares the database) - CI should confirm.